### PR TITLE
Add outbound receive workflow and module scaffolding

### DIFF
--- a/wms_app_flutter/lib/app_module.dart
+++ b/wms_app_flutter/lib/app_module.dart
@@ -7,6 +7,8 @@ import 'package:wms_app/modules/home/home_page.dart';
 import 'package:wms_app/modules/home/login/login_page.dart';
 import 'package:wms_app/services/api_service.dart';
 import 'modules/outbound/outbound_module.dart';
+import 'modules/feature_placeholder/feature_placeholder_bloc.dart';
+import 'modules/feature_placeholder/feature_placeholder_module.dart';
 
 /// 应用主模块
 class AppModule extends Module {
@@ -40,5 +42,109 @@ class AppModule extends Module {
 
     // 出库模块
     r.module('/outbound', module: OutboundModule());
+
+    // 其他模块占位路由
+    r.module(
+      '/arrival',
+      module: FeaturePlaceholderModule(
+        info: const FeaturePlaceholderInfo(
+          title: '到货接收',
+          description: '到货接收功能正在按平库出库模块标准进行Flutter重构。',
+          todoItems: [
+            '梳理到货接收业务流程',
+            '实现BLoC状态管理与列表查询',
+            '对接api.md中到货接收相关接口',
+          ],
+        ),
+      ),
+    );
+
+    r.module(
+      '/palletizing',
+      module: FeaturePlaceholderModule(
+        info: const FeaturePlaceholderInfo(
+          title: '立库组盘',
+          description: '立库组盘模块重构预研中，稍后将基于统一组件实现。',
+          todoItems: [
+            '迁移现有UniApp页面逻辑',
+            '抽象公共表格与扫码交互组件',
+          ],
+        ),
+      ),
+    );
+
+    r.module(
+      '/floor-inbound',
+      module: FeaturePlaceholderModule(
+        info: const FeaturePlaceholderInfo(
+          title: '平库入库',
+          description: '平库入库模块正在迁移至Flutter，敬请期待。',
+          todoItems: [
+            '梳理入库任务与采集接口',
+            '复用出库模块的分页、筛选及扫码架构',
+          ],
+        ),
+      ),
+    );
+
+    r.module(
+      '/online-picking',
+      module: FeaturePlaceholderModule(
+        info: const FeaturePlaceholderInfo(
+          title: '在线拣选',
+          description: '在线拣选将采用统一的任务列表 + 明细 + 采集模式。',
+        ),
+      ),
+    );
+
+    r.module(
+      '/pull-feeding',
+      module: FeaturePlaceholderModule(
+        info: const FeaturePlaceholderInfo(
+          title: '拉式发料',
+          description: '拉式发料模块重构排期中。',
+        ),
+      ),
+    );
+
+    r.module(
+      '/floor-count',
+      module: FeaturePlaceholderModule(
+        info: const FeaturePlaceholderInfo(
+          title: '平库盘点',
+          description: '平库盘点功能即将迁移，后续将支持离线缓存与差异分析。',
+        ),
+      ),
+    );
+
+    r.module(
+      '/floor-transfer',
+      module: FeaturePlaceholderModule(
+        info: const FeaturePlaceholderInfo(
+          title: '平库移库',
+          description: '平库移库流程将沿用BLoC + 通用表格方案。',
+        ),
+      ),
+    );
+
+    r.module(
+      '/warehouse-count',
+      module: FeaturePlaceholderModule(
+        info: const FeaturePlaceholderInfo(
+          title: '立库盘点',
+          description: '立库盘点迁移预定在下一阶段实施。',
+        ),
+      ),
+    );
+
+    r.module(
+      '/inventory-query',
+      module: FeaturePlaceholderModule(
+        info: const FeaturePlaceholderInfo(
+          title: '库存查询',
+          description: '库存查询模块将统一搜索、筛选与导出能力。',
+        ),
+      ),
+    );
   }
 }

--- a/wms_app_flutter/lib/modules/feature_placeholder/feature_placeholder_bloc.dart
+++ b/wms_app_flutter/lib/modules/feature_placeholder/feature_placeholder_bloc.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+
+part 'feature_placeholder_state.dart';
+
+class FeaturePlaceholderBloc
+    extends Cubit<FeaturePlaceholderState> {
+  FeaturePlaceholderBloc({required FeaturePlaceholderInfo info})
+      : super(FeaturePlaceholderState.initial(info));
+}
+
+class FeaturePlaceholderInfo extends Equatable {
+  final String title;
+  final String description;
+  final List<String> todoItems;
+
+  const FeaturePlaceholderInfo({
+    required this.title,
+    required this.description,
+    this.todoItems = const [],
+  });
+
+  @override
+  List<Object?> get props => [title, description, todoItems];
+}

--- a/wms_app_flutter/lib/modules/feature_placeholder/feature_placeholder_module.dart
+++ b/wms_app_flutter/lib/modules/feature_placeholder/feature_placeholder_module.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'feature_placeholder_bloc.dart';
+import 'feature_placeholder_page.dart';
+
+class FeaturePlaceholderModule extends Module {
+  final FeaturePlaceholderInfo info;
+
+  FeaturePlaceholderModule({required this.info});
+
+  @override
+  void binds(Injector i) {
+    i.add<FeaturePlaceholderBloc>(() => FeaturePlaceholderBloc(info: info));
+  }
+
+  @override
+  void routes(RouteManager r) {
+    r.child(
+      '/',
+      child: (_) => BlocProvider(
+        create: (context) => Modular.get<FeaturePlaceholderBloc>(),
+        child: const FeaturePlaceholderPage(),
+      ),
+    );
+  }
+}

--- a/wms_app_flutter/lib/modules/feature_placeholder/feature_placeholder_page.dart
+++ b/wms_app_flutter/lib/modules/feature_placeholder/feature_placeholder_page.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'feature_placeholder_bloc.dart';
+
+class FeaturePlaceholderPage extends StatelessWidget {
+  const FeaturePlaceholderPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF6F6F6),
+      appBar: AppBar(
+        title: BlocBuilder<FeaturePlaceholderBloc, FeaturePlaceholderState>(
+          builder: (context, state) => Text(state.info.title),
+        ),
+      ),
+      body: BlocBuilder<FeaturePlaceholderBloc, FeaturePlaceholderState>(
+        builder: (context, state) {
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Card(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(20.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      state.info.description,
+                      style: const TextStyle(fontSize: 16),
+                    ),
+                    const SizedBox(height: 24),
+                    if (state.info.todoItems.isNotEmpty)
+                      const Text(
+                        '后续待办：',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                        ),
+                      ),
+                    ...state.info.todoItems
+                        .map(
+                          (item) => ListTile(
+                            leading: const Icon(Icons.check_circle_outline),
+                            title: Text(item),
+                          ),
+                        )
+                        .toList(),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/wms_app_flutter/lib/modules/feature_placeholder/feature_placeholder_state.dart
+++ b/wms_app_flutter/lib/modules/feature_placeholder/feature_placeholder_state.dart
@@ -1,0 +1,14 @@
+part of 'feature_placeholder_bloc.dart';
+
+class FeaturePlaceholderState extends Equatable {
+  final FeaturePlaceholderInfo info;
+
+  const FeaturePlaceholderState({required this.info});
+
+  factory FeaturePlaceholderState.initial(FeaturePlaceholderInfo info) {
+    return FeaturePlaceholderState(info: info);
+  }
+
+  @override
+  List<Object?> get props => [info];
+}

--- a/wms_app_flutter/lib/modules/home/home_page.dart
+++ b/wms_app_flutter/lib/modules/home/home_page.dart
@@ -235,6 +235,7 @@ class _FunctionGrid extends StatelessWidget {
     FunctionItem('立库组盘', 'assets/images/home_icon_ palletizing.svg'),
     FunctionItem('平库入库', 'assets/images/home_icon_ inbound.svg'),
     FunctionItem('平库出库', 'assets/images/home_icon_ outbound.svg'),
+    FunctionItem('平库下架接收', 'assets/images/home_icon_ outbound.svg'),
     FunctionItem('在线拣选', 'assets/images/home_icon_online_picking.svg'),
     FunctionItem('拉式发料', 'assets/images/home_icon_pull_feeding.svg'),
     FunctionItem('平库盘点', 'assets/images/home_icon_floor_count.svg'),
@@ -289,6 +290,26 @@ class _FunctionGrid extends StatelessWidget {
         onTap: () {
           if (f.title == '平库出库') {
             Modular.to.pushNamed('/outbound');
+          } else if (f.title == '平库下架接收') {
+            Modular.to.pushNamed('/outbound/receive');
+          } else if (f.title == '到货接收') {
+            Modular.to.pushNamed('/arrival');
+          } else if (f.title == '立库组盘') {
+            Modular.to.pushNamed('/palletizing');
+          } else if (f.title == '平库入库') {
+            Modular.to.pushNamed('/floor-inbound');
+          } else if (f.title == '在线拣选') {
+            Modular.to.pushNamed('/online-picking');
+          } else if (f.title == '拉式发料') {
+            Modular.to.pushNamed('/pull-feeding');
+          } else if (f.title == '平库盘点') {
+            Modular.to.pushNamed('/floor-count');
+          } else if (f.title == '平库移库') {
+            Modular.to.pushNamed('/floor-transfer');
+          } else if (f.title == '立库盘点') {
+            Modular.to.pushNamed('/warehouse-count');
+          } else if (f.title == '库存查询') {
+            Modular.to.pushNamed('/inventory-query');
           } else {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(

--- a/wms_app_flutter/lib/modules/outbound/outbound_module.dart
+++ b/wms_app_flutter/lib/modules/outbound/outbound_module.dart
@@ -7,9 +7,14 @@ import 'package:wms_app/app_module.dart';
 import 'package:wms_app/modules/outbound/collection_task/bloc/collection_bloc.dart';
 import 'package:wms_app/modules/outbound/collection_task/outbound_collection_page.dart';
 import 'package:wms_app/modules/outbound/collection_task/services/collection_service.dart';
+import 'package:wms_app/modules/outbound/task_receive/bloc/receive_task_bloc.dart';
+import 'package:wms_app/modules/outbound/task_receive/bloc/receive_task_detail_bloc.dart';
+import 'package:wms_app/modules/outbound/task_receive/receive_task_detail_page.dart';
+import 'package:wms_app/modules/outbound/task_receive/receive_task_page.dart';
 
 import 'task_list/bloc/outbound_task_bloc.dart';
 import 'task_details/bloc/outbound_task_detail_bloc.dart';
+import 'task_list/models/outbound_task.dart';
 import 'services/outbound_task_service.dart';
 import 'task_list/outbound_task_list_page.dart';
 import 'task_details/outbound_task_detail_page.dart';
@@ -50,6 +55,20 @@ class OutboundModule extends Module {
 
     // 注册出库采集BLoC
     i.add<CollectionBloc>(() => CollectionBloc(i.get<CollectionService>()));
+
+    i.add<ReceiveTaskBloc>(
+      () => ReceiveTaskBloc(
+        outboundTaskService: i.get<OutboundTaskService>(),
+        userManager: i.get<UserManager>(),
+      ),
+    );
+
+    i.add<ReceiveTaskDetailBloc>(
+      () => ReceiveTaskDetailBloc(
+        i.get<OutboundTaskService>(),
+        i.get<UserManager>(),
+      ),
+    );
   }
 
   @override
@@ -111,6 +130,31 @@ class OutboundModule extends Module {
         return BlocProvider(
           create: (context) => Modular.get<CollectionBloc>(),
           child: OutboundCollectionPage(task: args.data['task'],),
+        );
+      },
+    );
+
+    // 出库接收任务列表
+    r.child(
+      '/receive',
+      child: (context) => BlocProvider(
+        create: (context) => Modular.get<ReceiveTaskBloc>(),
+        child: const ReceiveTaskPage(),
+      ),
+    );
+
+    // 出库接收任务明细
+    r.child(
+      '/receive/detail/:outTaskId',
+      child: (context) {
+        final args = Modular.args;
+        final task = args.data?['task'] as OutboundTask?;
+        if (task == null) {
+          throw ArgumentError('缺少出库接收任务数据');
+        }
+        return BlocProvider(
+          create: (context) => Modular.get<ReceiveTaskDetailBloc>(),
+          child: ReceiveTaskDetailPage(task: task),
         );
       },
     );

--- a/wms_app_flutter/lib/modules/outbound/services/outbound_task_service.dart
+++ b/wms_app_flutter/lib/modules/outbound/services/outbound_task_service.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:wms_app/modules/outbound/collection_task/models/collection_models.dart';
 import 'package:wms_app/services/api_response_handler.dart';
+import '../task_details/models/commit_task_item_result.dart';
 import '../task_list/models/outbound_task.dart';
 import '../task_details/models/outbound_task_item.dart';
 /// 出库任务服务
@@ -70,17 +71,39 @@ class OutboundTaskService {
   /// [operationType] 操作类型（'0'表示撤销）
   /// [confirm] 确认标志
   /// 返回撤销操作响应
-  Future<void> cancelOutboundTaskItems({
+  Future<CommitTaskItemResult> cancelOutboundTaskItems({
     required List<String> taskItemIds,
     String operationType = '0',
     String confirm = 'true',
+  }) {
+    return commitOutboundTaskItems(
+      taskItemIds: taskItemIds,
+      roomTag: operationType,
+      isCancel: confirm.toLowerCase() == 'true',
+    );
+  }
+
+  /// 提交/接收出库任务明细
+  Future<CommitTaskItemResult> commitOutboundTaskItems({
+    required List<String> taskItemIds,
+    String roomTag = '0',
+    bool isCancel = false,
   }) async {
     final response = await _dio.post<Map<String, dynamic>>(
       '/system/terminal/commitRCOutTaskItem',
       data: {
         'outtaskitemids': taskItemIds,
-        'roomTag': operationType,
-        'isCanel': confirm,
+        'roomTag': roomTag,
+        'isCanel': isCancel.toString(),
+      },
+    );
+
+    return ApiResponseHandler.handleResponse<CommitTaskItemResult>(
+      response: response,
+      dataExtractor: (data) {
+        return CommitTaskItemResult.fromJson(
+          Map<String, dynamic>.from(data as Map),
+        );
       },
     );
   }

--- a/wms_app_flutter/lib/modules/outbound/task_details/models/commit_task_item_result.dart
+++ b/wms_app_flutter/lib/modules/outbound/task_details/models/commit_task_item_result.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+
+/// 提交/撤销出库任务明细返回结果
+class CommitTaskItemResult extends Equatable {
+  final bool success;
+  final int processedCount;
+  final String action;
+
+  const CommitTaskItemResult({
+    required this.success,
+    required this.processedCount,
+    required this.action,
+  });
+
+  factory CommitTaskItemResult.fromJson(Map<String, dynamic> json) {
+    return CommitTaskItemResult(
+      success: json['success'] == true,
+      processedCount: int.tryParse(json['processedCount']?.toString() ?? '0') ?? 0,
+      action: json['action']?.toString() ?? '',
+    );
+  }
+
+  @override
+  List<Object?> get props => [success, processedCount, action];
+}

--- a/wms_app_flutter/lib/modules/outbound/task_receive/bloc/receive_task_bloc.dart
+++ b/wms_app_flutter/lib/modules/outbound/task_receive/bloc/receive_task_bloc.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/modules/outbound/task_list/models/outbound_task.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+import '../../services/outbound_task_service.dart';
+import 'receive_task_event.dart';
+import 'receive_task_state.dart';
+
+/// 平库出库接收任务列表BLoC
+class ReceiveTaskBloc extends Bloc<ReceiveTaskEvent, ReceiveTaskState> {
+  final OutboundTaskService outboundTaskService;
+  final UserManager userManager;
+
+  late OutboundTaskQuery currentQuery = _buildDefaultQuery();
+  late final CommonDataGridBloc<OutboundTask> gridBloc =
+      CommonDataGridBloc(dataLoader: _createLoader());
+
+  ReceiveTaskBloc({
+    required this.outboundTaskService,
+    required this.userManager,
+  }) : super(const ReceiveTaskState()) {
+    on<SearchReceiveTasksEvent>(_onSearch);
+    on<RefreshReceiveTasksEvent>(_onRefresh);
+  }
+
+  DataGridLoader<OutboundTask> _createLoader() {
+    return (int pageIndex) async {
+      final query = currentQuery.copyWith(pageIndex: pageIndex);
+      final data = await outboundTaskService.getOutboundTaskList(query: query);
+      final totalPages = (data.total / query.pageSize).ceil();
+
+      return DataGridResponseData<OutboundTask>(
+        totalPages: totalPages,
+        data: data.rows,
+      );
+    };
+  }
+
+  Future<void> _onSearch(
+    SearchReceiveTasksEvent event,
+    Emitter<ReceiveTaskState> emit,
+  ) async {
+    currentQuery = currentQuery.copyWith(
+      searchKey: event.searchKey,
+      pageIndex: 1,
+    );
+
+    final completer = Completer<DataGridResponseData<OutboundTask>>();
+    gridBloc.add(LoadDataEvent(currentQuery.pageIndex, completer: completer));
+    await completer.future;
+  }
+
+  Future<void> _onRefresh(
+    RefreshReceiveTasksEvent event,
+    Emitter<ReceiveTaskState> emit,
+  ) async {
+    gridBloc.add(LoadDataEvent(currentQuery.pageIndex));
+  }
+
+  OutboundTaskQuery _buildDefaultQuery() {
+    final userInfo = Modular.get<UserManager>().userInfo!;
+    return OutboundTaskQuery(
+      userId: 'ALL',
+      roleOrUserId: '${userInfo.userId}',
+      pageSize: 100,
+      finishFlag: '0',
+    );
+  }
+}

--- a/wms_app_flutter/lib/modules/outbound/task_receive/bloc/receive_task_detail_bloc.dart
+++ b/wms_app_flutter/lib/modules/outbound/task_receive/bloc/receive_task_detail_bloc.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/modules/outbound/task_details/models/outbound_task_item.dart';
+import 'package:wms_app/modules/outbound/task_list/models/outbound_task.dart';
+import 'package:wms_app/services/user_manager.dart';
+import 'package:wms_app/utils/error_handler.dart';
+
+import '../../services/outbound_task_service.dart';
+import 'receive_task_detail_event.dart';
+import 'receive_task_detail_state.dart';
+
+class ReceiveTaskDetailBloc
+    extends Bloc<ReceiveTaskDetailEvent, ReceiveTaskDetailState> {
+  final OutboundTaskService outboundTaskService;
+  final UserManager userManager;
+
+  ReceiveTaskDetailBloc(this.outboundTaskService, this.userManager)
+      : super(const ReceiveTaskDetailState()) {
+    on<SearchReceiveTaskItemsEvent>(_onSearch);
+    on<ReceiveSelectedItemsEvent>(_onReceiveSelected);
+    on<RefreshReceiveTaskItemsEvent>(_onRefresh);
+    _initGridBloc();
+  }
+
+  late final CommonDataGridBloc<OutboundTaskItem> gridBloc;
+  late OutboundTaskItemQuery currentQuery;
+
+  void _initGridBloc() {
+    gridBloc = CommonDataGridBloc<OutboundTaskItem>(
+      dataLoader: _createLoader(),
+      dataDeleter: _createReceiver(),
+    );
+  }
+
+  void initializeQuery(OutboundTask task) {
+    final userInfo = userManager.userInfo!;
+    currentQuery = OutboundTaskItemQuery(
+      outTaskId: task.outTaskId.toString(),
+      workStation: task.workStation,
+      userId: userInfo.userId,
+      roleOrUserId: userInfo.userId,
+      pageIndex: 1,
+      pageSize: 100,
+    );
+  }
+
+  DataGridLoader<OutboundTaskItem> _createLoader() {
+    return (int pageIndex) async {
+      currentQuery = currentQuery.copyWith(pageIndex: pageIndex);
+      final data = await outboundTaskService.getOutboundTaskItemList(
+        query: currentQuery,
+      );
+      final totalPages = (data.total / currentQuery.pageSize).ceil();
+
+      return DataGridResponseData<OutboundTaskItem>(
+        totalPages: totalPages,
+        data: data.rows,
+      );
+    };
+  }
+
+  DataGridDeleter _createReceiver() {
+    return (selectedRows) async {
+      final datas = gridBloc.state.data;
+      final ids = selectedRows.map((index) {
+        return datas[index].outTaskItemId.toString();
+      }).toList();
+
+      await outboundTaskService.commitOutboundTaskItems(
+        taskItemIds: ids,
+        isCancel: false,
+      );
+
+      gridBloc.add(const RefrenshLoadDataEvent<OutboundTaskItem>());
+    };
+  }
+
+  Future<void> _onSearch(
+    SearchReceiveTaskItemsEvent event,
+    Emitter<ReceiveTaskDetailState> emit,
+  ) async {
+    currentQuery = currentQuery.copyWith(
+      searchKey: event.searchKey,
+      pageIndex: 1,
+    );
+    gridBloc.add(LoadDataEvent(currentQuery.pageIndex));
+  }
+
+  Future<void> _onReceiveSelected(
+    ReceiveSelectedItemsEvent event,
+    Emitter<ReceiveTaskDetailState> emit,
+  ) async {
+    gridBloc.add(DeleteSelectedRowsEvent(event.selectedRows));
+  }
+
+  Future<void> _onRefresh(
+    RefreshReceiveTaskItemsEvent event,
+    Emitter<ReceiveTaskDetailState> emit,
+  ) async {
+    try {
+      gridBloc.add(LoadDataEvent(currentQuery.pageIndex));
+    } catch (e) {
+      emit(
+        state.copyWith(errorMessage: ErrorHandler.handleError(e)),
+      );
+    }
+  }
+}

--- a/wms_app_flutter/lib/modules/outbound/task_receive/bloc/receive_task_detail_event.dart
+++ b/wms_app_flutter/lib/modules/outbound/task_receive/bloc/receive_task_detail_event.dart
@@ -1,0 +1,33 @@
+import 'package:equatable/equatable.dart';
+
+abstract class ReceiveTaskDetailEvent extends Equatable {
+  const ReceiveTaskDetailEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class SearchReceiveTaskItemsEvent extends ReceiveTaskDetailEvent {
+  final String searchKey;
+
+  const SearchReceiveTaskItemsEvent(this.searchKey);
+
+  @override
+  List<Object?> get props => [searchKey];
+}
+
+class ReceiveSelectedItemsEvent extends ReceiveTaskDetailEvent {
+  final List<int> selectedRows;
+
+  const ReceiveSelectedItemsEvent(this.selectedRows);
+
+  @override
+  List<Object?> get props => [selectedRows];
+}
+
+class RefreshReceiveTaskItemsEvent extends ReceiveTaskDetailEvent {
+  const RefreshReceiveTaskItemsEvent();
+
+  @override
+  List<Object?> get props => [];
+}

--- a/wms_app_flutter/lib/modules/outbound/task_receive/bloc/receive_task_detail_state.dart
+++ b/wms_app_flutter/lib/modules/outbound/task_receive/bloc/receive_task_detail_state.dart
@@ -1,0 +1,24 @@
+import 'package:equatable/equatable.dart';
+
+class ReceiveTaskDetailState extends Equatable {
+  final bool isReceiving;
+  final String? errorMessage;
+
+  const ReceiveTaskDetailState({
+    this.isReceiving = false,
+    this.errorMessage,
+  });
+
+  ReceiveTaskDetailState copyWith({
+    bool? isReceiving,
+    String? errorMessage,
+  }) {
+    return ReceiveTaskDetailState(
+      isReceiving: isReceiving ?? this.isReceiving,
+      errorMessage: errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [isReceiving, errorMessage];
+}

--- a/wms_app_flutter/lib/modules/outbound/task_receive/bloc/receive_task_event.dart
+++ b/wms_app_flutter/lib/modules/outbound/task_receive/bloc/receive_task_event.dart
@@ -1,0 +1,27 @@
+import 'package:equatable/equatable.dart';
+
+/// 平库出库接收任务事件
+abstract class ReceiveTaskEvent extends Equatable {
+  const ReceiveTaskEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// 搜索任务
+class SearchReceiveTasksEvent extends ReceiveTaskEvent {
+  final String searchKey;
+
+  const SearchReceiveTasksEvent(this.searchKey);
+
+  @override
+  List<Object?> get props => [searchKey];
+}
+
+/// 刷新任务
+class RefreshReceiveTasksEvent extends ReceiveTaskEvent {
+  const RefreshReceiveTasksEvent();
+
+  @override
+  List<Object?> get props => [];
+}

--- a/wms_app_flutter/lib/modules/outbound/task_receive/bloc/receive_task_state.dart
+++ b/wms_app_flutter/lib/modules/outbound/task_receive/bloc/receive_task_state.dart
@@ -1,0 +1,8 @@
+import 'package:equatable/equatable.dart';
+
+class ReceiveTaskState extends Equatable {
+  const ReceiveTaskState();
+
+  @override
+  List<Object?> get props => [];
+}

--- a/wms_app_flutter/lib/modules/outbound/task_receive/config/receive_task_grid_config.dart
+++ b/wms_app_flutter/lib/modules/outbound/task_receive/config/receive_task_grid_config.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import '../../../../common_widgets/common_grid/common_data_grid.dart';
+import '../../task_list/models/outbound_task.dart';
+
+typedef ReceiveTaskOperation = void Function(OutboundTask task);
+
+class ReceiveTaskGridConfig {
+  static List<GridColumnConfig<OutboundTask>> columns(
+    ReceiveTaskOperation? onDetail,
+  ) {
+    return [
+      GridColumnConfig<OutboundTask>(
+        name: 'actions',
+        headerText: '操作',
+        width: 140,
+        valueGetter: (task) => '',
+        cellBuilder: (task, _, __) {
+          return SizedBox(
+            height: 32,
+            child: OutlinedButton(
+              onPressed: () => onDetail?.call(task),
+              style: OutlinedButton.styleFrom(
+                side: const BorderSide(color: Color(0xFF1E88E5)),
+                foregroundColor: const Color(0xFF1E88E5),
+              ),
+              child: const Text('明细'),
+            ),
+          );
+        },
+      ),
+      GridColumnConfig<OutboundTask>(
+        name: 'storeRoomNo',
+        headerText: '库房号',
+        width: 110,
+        valueGetter: (task) => task.storeRoomNo,
+      ),
+      GridColumnConfig<OutboundTask>(
+        name: 'orderNo',
+        headerText: '出库单号',
+        width: 180,
+        valueGetter: (task) => task.orderNo,
+      ),
+      GridColumnConfig<OutboundTask>(
+        name: 'poNumber',
+        headerText: '来源单号',
+        width: 180,
+        valueGetter: (task) => task.poNumber,
+      ),
+      GridColumnConfig<OutboundTask>(
+        name: 'workStation',
+        headerText: '工位',
+        width: 120,
+        valueGetter: (task) => task.workStation,
+      ),
+      GridColumnConfig<OutboundTask>(
+        name: 'outTaskNo',
+        headerText: '任务号',
+        width: 150,
+        valueGetter: (task) => task.outTaskNo,
+      ),
+      GridColumnConfig<OutboundTask>(
+        name: 'wipSupplementFlag',
+        headerText: '紧急补单',
+        width: 100,
+        valueGetter: (task) => task.wipSupplementFlag,
+      ),
+      GridColumnConfig<OutboundTask>(
+        name: 'scheduleGroupName',
+        headerText: '班组',
+        width: 160,
+        valueGetter: (task) => task.scheduleGroupName ?? '',
+      ),
+      GridColumnConfig<OutboundTask>(
+        name: 'taskComment',
+        headerText: '凭证号',
+        width: 160,
+        valueGetter: (task) => task.taskComment,
+      ),
+    ];
+  }
+}

--- a/wms_app_flutter/lib/modules/outbound/task_receive/receive_task_detail_page.dart
+++ b/wms_app_flutter/lib/modules/outbound/task_receive/receive_task_detail_page.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_state.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/modules/outbound/task_details/config/outbound_task_detail_grid_config.dart';
+import 'package:wms_app/modules/outbound/task_details/models/outbound_task_item.dart';
+import 'package:wms_app/modules/outbound/task_list/models/outbound_task.dart';
+
+import 'bloc/receive_task_detail_bloc.dart';
+import 'bloc/receive_task_detail_event.dart';
+import 'widgets/receive_batch_action_bar.dart';
+
+class ReceiveTaskDetailPage extends StatefulWidget {
+  final OutboundTask task;
+
+  const ReceiveTaskDetailPage({super.key, required this.task});
+
+  @override
+  State<ReceiveTaskDetailPage> createState() => _ReceiveTaskDetailPageState();
+}
+
+class _ReceiveTaskDetailPageState extends State<ReceiveTaskDetailPage> {
+  late ReceiveTaskDetailBloc _bloc;
+  late CommonDataGridBloc<OutboundTaskItem> _gridBloc;
+  final TextEditingController _searchController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<ReceiveTaskDetailBloc>(context);
+    _bloc.initializeQuery(widget.task);
+    _gridBloc = _bloc.gridBloc;
+    _gridBloc.add(LoadDataEvent(1));
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF6F6F6),
+      appBar: CustomAppBar(
+        title: '平库下架接收明细',
+        onBackPressed: () => Modular.to.pop(),
+      ).appBar,
+      body: Column(
+        children: [
+          _buildSearchBar(),
+          Expanded(child: _buildTable()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchBar() {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      decoration: const BoxDecoration(color: Colors.white),
+      child: TextField(
+        controller: _searchController,
+        decoration: InputDecoration(
+          hintText: '请扫描或输入物料编码',
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: BorderSide.none,
+          ),
+          filled: true,
+          fillColor: Colors.grey[200],
+          suffixIcon: ValueListenableBuilder<TextEditingValue>(
+            valueListenable: _searchController,
+            builder: (_, value, __) => value.text.isEmpty
+                ? const SizedBox.shrink()
+                : IconButton(
+                    icon: const Icon(Icons.clear),
+                    onPressed: () {
+                      _searchController.clear();
+                      _bloc.add(SearchReceiveTaskItemsEvent(''));
+                    },
+                  ),
+          ),
+        ),
+        onSubmitted: (value) {
+          _bloc.add(SearchReceiveTaskItemsEvent(value));
+        },
+      ),
+    );
+  }
+
+  Widget _buildTable() {
+    return BlocProvider.value(
+      value: _gridBloc,
+      child: BlocConsumer<CommonDataGridBloc<OutboundTaskItem>,
+          CommonDataGridState<OutboundTaskItem>>(
+        listener: (context, state) {
+          if (state.status == GridStatus.loading) {
+            LoadingDialogManager.instance.showLoadingDialog(context);
+          } else {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+          }
+
+          if (state.status == GridStatus.error) {
+            LoadingDialogManager.instance.showErrorDialog(
+              context,
+              state.errorMessage ?? '加载失败',
+            );
+          } else if (state.status == GridStatus.success) {
+            LoadingDialogManager.instance.showSnackSuccessMsg(
+              context,
+              '接收成功',
+              duration: const Duration(milliseconds: 800),
+            );
+          }
+        },
+        builder: (context, state) {
+          return Column(
+            children: [
+              Expanded(
+                child: CommonDataGrid<OutboundTaskItem>(
+                  columns: OutboundTaskDetailGridConfig.getColumns(),
+                  datas: state.data,
+                  currentPage: state.currentPage,
+                  totalPages: state.totalPages,
+                  allowPager: true,
+                  allowSelect: true,
+                  selectedRows: state.selectedRows,
+                  onSelectionChanged: (rows) {
+                    _gridBloc.add(ChangeSelectedRowsEvent(rows));
+                  },
+                  onLoadData: (pageIndex) async {
+                    _gridBloc.add(LoadDataEvent(pageIndex));
+                  },
+                ),
+              ),
+              BlocBuilder<CommonDataGridBloc<OutboundTaskItem>,
+                  CommonDataGridState<OutboundTaskItem>>(
+                builder: (context, gridState) {
+                  return ReceiveBatchActionBar(
+                    selectedCount: gridState.selectedRows.length,
+                    totalCount: gridState.data.length,
+                    onClear: () {
+                      _gridBloc.add(const ChangeSelectedRowsEvent([]));
+                    },
+                    onConfirm: () {
+                      _bloc.add(
+                        ReceiveSelectedItemsEvent(gridState.selectedRows),
+                      );
+                    },
+                  );
+                },
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/wms_app_flutter/lib/modules/outbound/task_receive/receive_task_page.dart
+++ b/wms_app_flutter/lib/modules/outbound/task_receive/receive_task_page.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_state.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/modules/outbound/task_list/models/outbound_task.dart';
+
+import 'bloc/receive_task_bloc.dart';
+import 'bloc/receive_task_event.dart';
+import 'config/receive_task_grid_config.dart';
+
+class ReceiveTaskPage extends StatefulWidget {
+  const ReceiveTaskPage({super.key});
+
+  @override
+  State<ReceiveTaskPage> createState() => _ReceiveTaskPageState();
+}
+
+class _ReceiveTaskPageState extends State<ReceiveTaskPage> {
+  late final ReceiveTaskBloc _bloc;
+  late final CommonDataGridBloc<OutboundTask> _gridBloc;
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<ReceiveTaskBloc>(context);
+    _gridBloc = _bloc.gridBloc;
+    _gridBloc.add(LoadDataEvent(1));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF6F6F6),
+      appBar: CustomAppBar(
+        title: '平库下架接收',
+        onBackPressed: () => Modular.to.pop(),
+      ).appBar,
+      body: Column(
+        children: [
+          _buildSearchBar(),
+          Expanded(child: _buildTable()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchBar() {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      decoration: const BoxDecoration(color: Colors.white),
+      child: TextField(
+        controller: _controller,
+        decoration: InputDecoration(
+          hintText: '请扫描单号',
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: BorderSide.none,
+          ),
+          filled: true,
+          fillColor: Colors.grey[200],
+          suffixIcon: ValueListenableBuilder<TextEditingValue>(
+            valueListenable: _controller,
+            builder: (_, value, __) => value.text.isEmpty
+                ? const SizedBox.shrink()
+                : IconButton(
+                    icon: const Icon(Icons.clear),
+                    onPressed: () {
+                      _controller.clear();
+                      _bloc.add(const SearchReceiveTasksEvent(''));
+                    },
+                  ),
+          ),
+        ),
+        onSubmitted: (value) {
+          _bloc.add(SearchReceiveTasksEvent(value));
+        },
+      ),
+    );
+  }
+
+  Widget _buildTable() {
+    return BlocProvider.value(
+      value: _gridBloc,
+      child: BlocConsumer<CommonDataGridBloc<OutboundTask>,
+          CommonDataGridState<OutboundTask>>(
+        listener: (context, state) {
+          if (state.status == GridStatus.loading) {
+            LoadingDialogManager.instance.showLoadingDialog(context);
+          } else {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+          }
+
+          if (state.status == GridStatus.error) {
+            LoadingDialogManager.instance.showErrorDialog(
+              context,
+              state.errorMessage ?? '加载失败',
+            );
+          }
+        },
+        builder: (context, state) {
+          return CommonDataGrid<OutboundTask>(
+            columns: ReceiveTaskGridConfig.columns((task) {
+              Modular.to.pushNamed(
+                '/outbound/receive/detail/${task.outTaskId}',
+                arguments: {'task': task},
+              );
+            }),
+            datas: state.data,
+            currentPage: state.currentPage,
+            totalPages: state.totalPages,
+            allowPager: true,
+            allowSelect: false,
+            onLoadData: (pageIndex) async {
+              _gridBloc.add(LoadDataEvent(pageIndex));
+            },
+            selectedRows: const [],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/wms_app_flutter/lib/modules/outbound/task_receive/widgets/receive_batch_action_bar.dart
+++ b/wms_app_flutter/lib/modules/outbound/task_receive/widgets/receive_batch_action_bar.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+class ReceiveBatchActionBar extends StatelessWidget {
+  final int selectedCount;
+  final int totalCount;
+  final VoidCallback onConfirm;
+  final VoidCallback onClear;
+
+  const ReceiveBatchActionBar({
+    Key? key,
+    required this.selectedCount,
+    required this.totalCount,
+    required this.onConfirm,
+    required this.onClear,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (selectedCount == 0) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.1),
+            blurRadius: 4,
+            offset: const Offset(0, -1),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                '已选择 $selectedCount / $totalCount 项',
+                style: const TextStyle(fontSize: 14),
+              ),
+            ),
+            TextButton(
+              onPressed: onClear,
+              child: const Text('清除'),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(
+              onPressed: onConfirm,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF1E88E5),
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('接收'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement the outbound receive task list/detail workflows with BLoC, reusable grid configs, and modular routes
- extend the outbound task service with a typed commit result model and wire the new flows into the home navigation
- scaffold placeholder Modular+BLoC routes for the remaining feature entries so they follow the outbound module pattern

## Testing
- `flutter format lib` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68dea0b60fb48330a952593a6f327568