### PR TITLE
feat: migrate outbound exception collection to flutter

### DIFF
--- a/wms_app_flutter/lib/modules/outbound/collection_task/outbound_collection_page.dart
+++ b/wms_app_flutter/lib/modules/outbound/collection_task/outbound_collection_page.dart
@@ -15,6 +15,7 @@ import 'bloc/collection_bloc.dart';
 import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
 import 'package:wms_app/modules/outbound/collection_task/outbound_collection_result_page.dart';
 import 'package:wms_app/modules/outbound/collection_task/models/deleted_payload.dart';
+import 'package:wms_app/modules/outbound/exception_collection/models/exception_collection_args.dart';
 
 class OutboundCollectionPage extends StatefulWidget {
   final OutboundTask task;
@@ -608,7 +609,14 @@ class _OutboundCollectionPageState extends State<OutboundCollectionPage>
     switch (action) {
       case 'exception':
         // 导航到异常采集页面
-        Modular.to.pushNamed('/exception');
+        Modular.to.pushNamed(
+          '/outbound/exception',
+          arguments: ExceptionCollectionArgs(
+            task: widget.task,
+            trayNo: '',
+            storeSite: _bloc.state.storeSite,
+          ),
+        );
         break;
       case 'shortage':
         _handleShortageAction(context);

--- a/wms_app_flutter/lib/modules/outbound/collection_task/services/collection_service.dart
+++ b/wms_app_flutter/lib/modules/outbound/collection_task/services/collection_service.dart
@@ -138,4 +138,56 @@ class CollectionService {
     );
     return response.data;
   }
+
+  Future<String?> getPalletStoreSite(String trayNo) async {
+    final response = await _dio.get(
+      '/system/terminal/getPalletSiteNo',
+      queryParameters: {'taskNo': trayNo},
+    );
+
+    final data = response.data;
+    if (data is! Map<String, dynamic>) {
+      throw Exception('响应格式错误');
+    }
+
+    final code = data['code'] as int?;
+    if (code != 200) {
+      throw Exception(data['msg']?.toString() ?? '获取托盘库位失败');
+    }
+
+    final sites = data['data'];
+    if (sites is List && sites.isNotEmpty) {
+      final first = sites.first;
+      if (first is Map<String, dynamic>) {
+        final site = first['storesiteno'] ?? first['storeSiteNo'];
+        if (site != null) {
+          return site.toString();
+        }
+      }
+    }
+
+    return null;
+  }
+
+  Future<void> commitExceptionShelves(
+    List<Map<String, dynamic>> exceptionInfos,
+  ) async {
+    final response = await _dio.post(
+      '/system/terminal/commitExceptShelves',
+      data: {'exceptShelvesInfos': exceptionInfos},
+      options: Options(
+        headers: {'content-type': 'application/json;charset=UTF-8'},
+      ),
+    );
+
+    final data = response.data;
+    if (data is! Map<String, dynamic>) {
+      throw Exception('响应格式错误');
+    }
+
+    final code = data['code'] as int?;
+    if (code != 200) {
+      throw Exception(data['msg']?.toString() ?? '异常采集提交失败');
+    }
+  }
 }

--- a/wms_app_flutter/lib/modules/outbound/exception_collection/bloc/exception_collection_bloc.dart
+++ b/wms_app_flutter/lib/modules/outbound/exception_collection/bloc/exception_collection_bloc.dart
@@ -1,0 +1,399 @@
+
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:uuid/uuid.dart';
+import 'package:wms_app/modules/outbound/collection_task/models/collection_models.dart';
+import 'package:wms_app/modules/outbound/collection_task/services/collection_service.dart';
+import 'package:wms_app/modules/outbound/exception_collection/models/exception_collection_models.dart';
+
+import '../../task_list/models/outbound_task.dart';
+import 'exception_collection_event.dart';
+import 'exception_collection_state.dart';
+
+class ExceptionCollectionBloc
+    extends Bloc<ExceptionCollectionEvent, ExceptionCollectionState> {
+  final CollectionService _service;
+  static const String _defaultProType = '平库下架';
+  late OutboundTask _task;
+
+  ExceptionCollectionBloc(this._service)
+      : super(const ExceptionCollectionState()) {
+    on<InitializeExceptionCollectionEvent>(_onInitialize);
+    on<ExceptionTypeChangedEvent>(_onTypeChanged);
+    on<ExceptionPerformScanEvent>(_onPerformScan);
+    on<ExceptionSelectionChangedEvent>(_onSelectionChanged);
+    on<ExceptionDeleteSelectedEvent>(_onDeleteSelected);
+    on<ExceptionCommitRequestedEvent>(_onCommitRequested);
+    on<ExceptionClearErrorEvent>(_onClearError);
+    on<ExceptionClearMessageEvent>(_onClearMessage);
+  }
+
+  FutureOr<void> _onInitialize(
+    InitializeExceptionCollectionEvent event,
+    Emitter<ExceptionCollectionState> emit,
+  ) {
+    _task = event.task;
+    var nextState = state.copyWith(
+      trayNo: event.trayNo,
+      storeSite: event.initialStoreSite,
+      barcodeContent: BarcodeContent.fromJson({}),
+      collectQty: 0,
+      matCode: '',
+      batchNo: '',
+      sn: '',
+      matControlFlag: '',
+    );
+    nextState = _applyPlaceholder(nextState);
+    emit(nextState);
+  }
+
+  FutureOr<void> _onTypeChanged(
+    ExceptionTypeChangedEvent event,
+    Emitter<ExceptionCollectionState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        exceptionType: event.type,
+        exceptionName: event.name,
+      ),
+    );
+  }
+
+  Future<void> _onPerformScan(
+    ExceptionPerformScanEvent event,
+    Emitter<ExceptionCollectionState> emit,
+  ) async {
+    final barcode = event.barcode.trim();
+
+    if (state.exceptionType.isEmpty) {
+      emit(state.copyWith(error: '请指定异常类型!'));
+      return;
+    }
+
+    if (barcode.isEmpty) {
+      emit(state.copyWith(error: '采集内容为空,请重新采集!'));
+      return;
+    }
+
+    try {
+      var workingState = state;
+
+      if (barcode.contains('MC')) {
+        emit(workingState.copyWith(isLoading: true, error: null));
+        final barcodeContent = await _service.getMaterialInfoByQR(barcode);
+        workingState = state; // 更新为加载状态
+        workingState = _handleQRCode(
+          workingState.copyWith(isLoading: false),
+          barcodeContent,
+        );
+      } else if (barcode.contains(r'$KW$')) {
+        workingState = _handleSite(workingState.copyWith(error: null), barcode);
+      } else if (barcode.contains(r'$TP$')) {
+        emit(workingState.copyWith(isLoading: true, error: null));
+        workingState = state;
+        workingState = await _handleTray(
+          workingState.copyWith(isLoading: false),
+          barcode,
+        );
+      } else if (_isNumeric(barcode)) {
+        workingState = _handleQuantity(workingState, barcode);
+      } else {
+        throw Exception('采集内容不合法!');
+      }
+
+      workingState = _applyPlaceholder(workingState);
+      if (workingState.placeholder.isEmpty) {
+        workingState = _finalizeCollection(workingState);
+      }
+
+      emit(workingState);
+    } catch (e) {
+      var resetState = state.copyWith(
+        isLoading: false,
+        error: _formatError(e),
+        barcodeContent: BarcodeContent.fromJson({}),
+        collectQty: 0,
+        matCode: '',
+        batchNo: '',
+        sn: '',
+        matControlFlag: '',
+      );
+      resetState = _applyPlaceholder(resetState);
+      emit(resetState);
+    }
+  }
+
+  ExceptionCollectionState _handleQRCode(
+    ExceptionCollectionState current,
+    BarcodeContent barcodeContent,
+  ) {
+    final matControl = barcodeContent.seqctrl?.toString() ?? '';
+    final newMartTask = barcodeContent.id_old?.toString() ?? '';
+
+    String newBatchNo = current.batchNo;
+    String newSn = current.sn;
+    double newCollectQty = current.collectQty;
+
+    if (matControl == '0') {
+      final snValue = barcodeContent.sn?.trim() ?? '';
+      if (snValue.isEmpty) {
+        throw Exception('物料【${barcodeContent.matcode ?? ''}】序列号不能为空');
+      }
+      newSn = snValue;
+      newBatchNo = newMartTask == '1' ? (barcodeContent.batchno ?? '') : '';
+      newCollectQty = 1;
+    } else if (matControl == '1' || matControl == '2') {
+      final batchValue = newMartTask == '1'
+          ? (barcodeContent.batchno ?? '')
+          : (barcodeContent.sn ?? '');
+      if (batchValue.isEmpty) {
+        throw Exception('物料【${barcodeContent.matcode ?? ''}】批次号不能为空');
+      }
+      newBatchNo = batchValue;
+      newSn = newMartTask == '1' ? (barcodeContent.sn ?? '') : '';
+      newCollectQty = 0;
+    } else {
+      throw Exception('物料${barcodeContent.matcode ?? ''}编码控制维护值维护不合法');
+    }
+
+    return current.copyWith(
+      barcodeContent: barcodeContent,
+      matCode: barcodeContent.matcode ?? '',
+      matControlFlag: matControl,
+      batchNo: newBatchNo,
+      sn: newSn,
+      collectQty: newCollectQty,
+    );
+  }
+
+  ExceptionCollectionState _handleSite(
+    ExceptionCollectionState current,
+    String barcode,
+  ) {
+    final parts = barcode.split(r'$');
+    if (parts.length < 3 || parts[2].isEmpty) {
+      throw Exception('库位编码不合法');
+    }
+    return current.copyWith(storeSite: parts[2]);
+  }
+
+  Future<ExceptionCollectionState> _handleTray(
+    ExceptionCollectionState current,
+    String barcode,
+  ) async {
+    final parts = barcode.split(r'$');
+    if (parts.length < 3 || parts[2].isEmpty) {
+      throw Exception('托盘号不能为空');
+    }
+    final trayNo = parts[2];
+    final storeSite = await _service.getPalletStoreSite(trayNo);
+    if (storeSite == null || storeSite.isEmpty) {
+      throw Exception('托盘未绑定库位');
+    }
+    return current.copyWith(trayNo: trayNo, storeSite: storeSite);
+  }
+
+  ExceptionCollectionState _handleQuantity(
+    ExceptionCollectionState current,
+    String barcode,
+  ) {
+    if (current.matCode.isEmpty) {
+      throw Exception('请先扫描二维码');
+    }
+    if (current.matControlFlag == '0') {
+      throw Exception('已采集序列号无需采集数量，请扫描二维码');
+    }
+    final qty = double.tryParse(barcode);
+    if (qty == null || qty <= 0) {
+      throw Exception('采集数量必须大于0');
+    }
+    return current.copyWith(collectQty: qty);
+  }
+
+  ExceptionCollectionState _finalizeCollection(
+    ExceptionCollectionState current,
+  ) {
+    if (current.matCode.isEmpty) {
+      throw Exception('请先扫描二维码');
+    }
+    if (current.collectQty <= 0) {
+      throw Exception('采集数量必须大于0');
+    }
+
+    final id = const Uuid().v4();
+    final item = ExceptionCollectionItem(
+      id: id,
+      matCode: current.matCode,
+      storeSite: current.storeSite,
+      exceptionName: current.exceptionName,
+      qty: current.collectQty,
+      batchNo: current.batchNo,
+      sn: current.sn,
+      storeRoom: _task.storeRoomNo,
+      proType: _defaultProType,
+      taskId: _task.outTaskId.toString(),
+    );
+
+    final stock = ExceptionStock(
+      id: id,
+      matCode: current.matCode,
+      batchNo: current.batchNo,
+      sn: current.sn,
+      taskQty: 0,
+      collectQty: current.collectQty,
+      storeRoom: _task.storeRoomNo,
+      storeSite: current.storeSite,
+      taskId: _task.outTaskId.toString(),
+      exceptionType: current.exceptionType,
+    );
+
+    final updatedItems = List<ExceptionCollectionItem>.from(current.items)
+      ..add(item);
+    final updatedStocks = List<ExceptionStock>.from(current.stocks)..add(stock);
+
+    var nextState = current.copyWith(
+      items: List.unmodifiable(updatedItems),
+      stocks: List.unmodifiable(updatedStocks),
+      selectedIds: const [],
+      barcodeContent: BarcodeContent.fromJson({}),
+      collectQty: 0,
+      matCode: '',
+      batchNo: '',
+      sn: '',
+      matControlFlag: '',
+    );
+    nextState = _applyPlaceholder(nextState);
+    return nextState;
+  }
+
+  FutureOr<void> _onSelectionChanged(
+    ExceptionSelectionChangedEvent event,
+    Emitter<ExceptionCollectionState> emit,
+  ) {
+    emit(state.copyWith(selectedIds: List.unmodifiable(event.selectedIds)));
+  }
+
+  FutureOr<void> _onDeleteSelected(
+    ExceptionDeleteSelectedEvent event,
+    Emitter<ExceptionCollectionState> emit,
+  ) {
+    if (state.selectedIds.isEmpty) {
+      emit(state.copyWith(error: '请至少选择一行记录'));
+      return;
+    }
+
+    final idSet = state.selectedIds.toSet();
+    final remainingItems =
+        state.items.where((item) => !idSet.contains(item.id)).toList();
+    final remainingStocks =
+        state.stocks.where((stock) => !idSet.contains(stock.id)).toList();
+
+    emit(
+      state.copyWith(
+        items: List.unmodifiable(remainingItems),
+        stocks: List.unmodifiable(remainingStocks),
+        selectedIds: const [],
+      ),
+    );
+  }
+
+  Future<void> _onCommitRequested(
+    ExceptionCommitRequestedEvent event,
+    Emitter<ExceptionCollectionState> emit,
+  ) async {
+    if (state.stocks.isEmpty) {
+      emit(state.copyWith(error: '本次采集明细，请确认！'));
+      return;
+    }
+
+    emit(state.copyWith(isLoading: true, error: null));
+
+    try {
+      final payload = state.stocks
+          .map(
+            (stock) => stock.toPayload(
+              taskNo: _task.outTaskNo,
+              proType: _defaultProType,
+              proofNo: _task.taskComment,
+            ),
+          )
+          .toList();
+
+      await _service.commitExceptionShelves(payload);
+
+      var clearedState = state.copyWith(
+        isLoading: false,
+        successMessage: '提交成功',
+        items: const [],
+        stocks: const [],
+        selectedIds: const [],
+        barcodeContent: BarcodeContent.fromJson({}),
+        collectQty: 0,
+        matCode: '',
+        batchNo: '',
+        sn: '',
+        matControlFlag: '',
+        storeSite: '',
+      );
+      clearedState = _applyPlaceholder(clearedState);
+      emit(clearedState);
+    } catch (e) {
+      emit(
+        state.copyWith(
+          isLoading: false,
+          error: '提交异常：${_formatError(e)}',
+        ),
+      );
+    }
+  }
+
+  FutureOr<void> _onClearError(
+    ExceptionClearErrorEvent event,
+    Emitter<ExceptionCollectionState> emit,
+  ) {
+    emit(state.copyWith(error: null));
+  }
+
+  FutureOr<void> _onClearMessage(
+    ExceptionClearMessageEvent event,
+    Emitter<ExceptionCollectionState> emit,
+  ) {
+    emit(state.copyWith(successMessage: null));
+  }
+
+  ExceptionCollectionState _applyPlaceholder(
+    ExceptionCollectionState current,
+  ) {
+    final placeholder = _computePlaceholder(current);
+    return current.copyWith(
+      placeholder: placeholder,
+      focus: placeholder == '请输入数量',
+    );
+  }
+
+  String _computePlaceholder(ExceptionCollectionState current) {
+    if (current.storeSite.isEmpty) {
+      return '请扫描库位';
+    }
+    if (current.matCode.isEmpty) {
+      return '请扫描二维码';
+    }
+    if (current.matControlFlag == '0') {
+      return '';
+    }
+    if (current.collectQty <= 0) {
+      return '请输入数量';
+    }
+    return '';
+  }
+
+  String _formatError(Object error) {
+    final message = error.toString();
+    return message.replaceFirst('Exception: ', '');
+  }
+
+  bool _isNumeric(String value) {
+    return RegExp(r'^[0-9]+(\.[0-9]+)?$').hasMatch(value);
+  }
+}

--- a/wms_app_flutter/lib/modules/outbound/exception_collection/bloc/exception_collection_event.dart
+++ b/wms_app_flutter/lib/modules/outbound/exception_collection/bloc/exception_collection_event.dart
@@ -1,0 +1,68 @@
+import 'package:equatable/equatable.dart';
+import 'package:wms_app/modules/outbound/task_list/models/outbound_task.dart';
+
+abstract class ExceptionCollectionEvent extends Equatable {
+  const ExceptionCollectionEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class InitializeExceptionCollectionEvent extends ExceptionCollectionEvent {
+  final OutboundTask task;
+  final String trayNo;
+  final String initialStoreSite;
+
+  const InitializeExceptionCollectionEvent({
+    required this.task,
+    this.trayNo = '',
+    this.initialStoreSite = '',
+  });
+
+  @override
+  List<Object?> get props => [task, trayNo, initialStoreSite];
+}
+
+class ExceptionTypeChangedEvent extends ExceptionCollectionEvent {
+  final String type;
+  final String name;
+
+  const ExceptionTypeChangedEvent({required this.type, required this.name});
+
+  @override
+  List<Object?> get props => [type, name];
+}
+
+class ExceptionPerformScanEvent extends ExceptionCollectionEvent {
+  final String barcode;
+
+  const ExceptionPerformScanEvent(this.barcode);
+
+  @override
+  List<Object?> get props => [barcode];
+}
+
+class ExceptionSelectionChangedEvent extends ExceptionCollectionEvent {
+  final List<String> selectedIds;
+
+  const ExceptionSelectionChangedEvent(this.selectedIds);
+
+  @override
+  List<Object?> get props => [selectedIds];
+}
+
+class ExceptionDeleteSelectedEvent extends ExceptionCollectionEvent {
+  const ExceptionDeleteSelectedEvent();
+}
+
+class ExceptionCommitRequestedEvent extends ExceptionCollectionEvent {
+  const ExceptionCommitRequestedEvent();
+}
+
+class ExceptionClearErrorEvent extends ExceptionCollectionEvent {
+  const ExceptionClearErrorEvent();
+}
+
+class ExceptionClearMessageEvent extends ExceptionCollectionEvent {
+  const ExceptionClearMessageEvent();
+}

--- a/wms_app_flutter/lib/modules/outbound/exception_collection/bloc/exception_collection_state.dart
+++ b/wms_app_flutter/lib/modules/outbound/exception_collection/bloc/exception_collection_state.dart
@@ -1,0 +1,92 @@
+import 'package:wms_app/modules/outbound/collection_task/models/collection_models.dart';
+import 'package:wms_app/modules/outbound/exception_collection/models/exception_collection_models.dart';
+
+class ExceptionCollectionState {
+  final String placeholder;
+  final bool focus;
+  final bool isLoading;
+  final String? error;
+  final String? successMessage;
+  final String storeSite;
+  final String trayNo;
+  final BarcodeContent? barcodeContent;
+  final double collectQty;
+  final String exceptionType;
+  final String exceptionName;
+  final List<ExceptionCollectionItem> items;
+  final List<String> selectedIds;
+  final List<ExceptionStock> stocks;
+  final String matCode;
+  final String batchNo;
+  final String sn;
+  final String matControlFlag;
+
+  const ExceptionCollectionState({
+    this.placeholder = '请扫描库位',
+    this.focus = false,
+    this.isLoading = false,
+    this.error,
+    this.successMessage,
+    this.storeSite = '',
+    this.trayNo = '',
+    this.barcodeContent,
+    this.collectQty = 0,
+    this.exceptionType = '',
+    this.exceptionName = '',
+    this.items = const [],
+    this.selectedIds = const [],
+    this.stocks = const [],
+    this.matCode = '',
+    this.batchNo = '',
+    this.sn = '',
+    this.matControlFlag = '',
+  });
+
+  static const _undefined = Object();
+
+  ExceptionCollectionState copyWith({
+    String? placeholder,
+    bool? focus,
+    bool? isLoading,
+    Object? error = _undefined,
+    Object? successMessage = _undefined,
+    String? storeSite,
+    String? trayNo,
+    Object? barcodeContent = _undefined,
+    double? collectQty,
+    String? exceptionType,
+    String? exceptionName,
+    List<ExceptionCollectionItem>? items,
+    List<String>? selectedIds,
+    List<ExceptionStock>? stocks,
+    String? matCode,
+    String? batchNo,
+    String? sn,
+    String? matControlFlag,
+  }) {
+    return ExceptionCollectionState(
+      placeholder: placeholder ?? this.placeholder,
+      focus: focus ?? this.focus,
+      isLoading: isLoading ?? this.isLoading,
+      error: identical(error, _undefined) ? this.error : error as String?,
+      successMessage: identical(successMessage, _undefined)
+          ? this.successMessage
+          : successMessage as String?,
+      storeSite: storeSite ?? this.storeSite,
+      trayNo: trayNo ?? this.trayNo,
+      barcodeContent: identical(barcodeContent, _undefined)
+          ? this.barcodeContent
+          : barcodeContent as BarcodeContent?,
+      collectQty: collectQty ?? this.collectQty,
+      exceptionType: exceptionType ?? this.exceptionType,
+      exceptionName: exceptionName ?? this.exceptionName,
+      items: items ?? this.items,
+      selectedIds: selectedIds ?? this.selectedIds,
+      stocks: stocks ?? this.stocks,
+      matCode: matCode ?? this.matCode,
+      batchNo: batchNo ?? this.batchNo,
+      sn: sn ?? this.sn,
+      matControlFlag: matControlFlag ?? this.matControlFlag,
+    );
+  }
+}

--- a/wms_app_flutter/lib/modules/outbound/exception_collection/exception_collection_page.dart
+++ b/wms_app_flutter/lib/modules/outbound/exception_collection/exception_collection_page.dart
@@ -1,0 +1,532 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/modules/outbound/exception_collection/bloc/exception_collection_bloc.dart';
+import 'package:wms_app/modules/outbound/exception_collection/bloc/exception_collection_event.dart';
+import 'package:wms_app/modules/outbound/exception_collection/bloc/exception_collection_state.dart';
+import 'package:wms_app/modules/outbound/exception_collection/models/exception_collection_args.dart';
+import 'package:wms_app/modules/outbound/exception_collection/models/exception_collection_models.dart';
+import 'package:wms_app/services/scanner_service.dart';
+
+class ExceptionCollectionPage extends StatefulWidget {
+  final ExceptionCollectionArgs args;
+
+  const ExceptionCollectionPage({super.key, required this.args});
+
+  @override
+  State<ExceptionCollectionPage> createState() =>
+      _ExceptionCollectionPageState();
+}
+
+class _ExceptionCollectionPageState extends State<ExceptionCollectionPage> {
+  final TextEditingController _controller = TextEditingController();
+  final FocusNode _focusNode = FocusNode();
+  late ExceptionCollectionBloc _bloc;
+  StreamSubscription<String>? _scanSubscription;
+
+  static const List<ExceptionTypeOption> _exceptionOptions = [
+    ExceptionTypeOption(value: '010', label: '小包装发料'),
+    ExceptionTypeOption(value: '006', label: '整包装多料'),
+    ExceptionTypeOption(value: '007', label: '整包装少料'),
+    ExceptionTypeOption(value: '008', label: '混料'),
+    ExceptionTypeOption(value: '009', label: '质量问题'),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<ExceptionCollectionBloc>(context);
+    _bloc.add(
+      InitializeExceptionCollectionEvent(
+        task: widget.args.task,
+        trayNo: widget.args.trayNo ?? '',
+        initialStoreSite: widget.args.storeSite ?? '',
+      ),
+    );
+
+    _scanSubscription = ScannerService.instance.stream.listen(
+      (code) {
+        if (code.isEmpty || !mounted) return;
+        final isCurrent = ModalRoute.of(context)?.isCurrent ?? false;
+        if (!isCurrent) return;
+        _bloc.add(ExceptionPerformScanEvent(code));
+      },
+      onError: (error) {
+        if (!mounted) return;
+        _showErrorDialog('扫码组件出错：$error');
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _scanSubscription?.cancel();
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async {
+        final canLeave = await _confirmLeaveIfNeeded();
+        if (canLeave) {
+          return true;
+        }
+        return false;
+      },
+      child: Scaffold(
+        backgroundColor: const Color(0xFFF6F6F6),
+        appBar: AppBar(
+          backgroundColor: const Color(0xFF1976D2),
+          centerTitle: true,
+          elevation: 0,
+          title: const Text(
+            '异常采集',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back_ios, color: Colors.white),
+            onPressed: () async {
+              final canLeave = await _confirmLeaveIfNeeded();
+              if (canLeave && mounted) {
+                Modular.to.pop();
+              }
+            },
+          ),
+        ),
+        body: BlocConsumer<ExceptionCollectionBloc, ExceptionCollectionState>(
+          listener: (context, state) {
+            if (state.isLoading) {
+              LoadingDialogManager.instance.showLoadingDialog(context);
+            } else {
+              LoadingDialogManager.instance.hideLoadingDialog(context);
+            }
+
+            if (state.error != null) {
+              _showErrorDialog(state.error!);
+              _bloc.add(const ExceptionClearErrorEvent());
+            }
+
+            if (state.successMessage != null) {
+              LoadingDialogManager.instance.showSnackSuccessMsg(
+                context,
+                state.successMessage!,
+                duration: const Duration(milliseconds: 800),
+              );
+              _bloc.add(const ExceptionClearMessageEvent());
+              if (mounted) Modular.to.pop();
+            }
+
+            if (state.focus) {
+              _focusNode.requestFocus();
+            }
+
+            _controller.clear();
+          },
+          builder: (context, state) {
+            return Column(
+              children: [
+                _buildScanInput(state.placeholder),
+                _buildInfoCard(state),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    child: _buildDataGrid(state),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+        bottomNavigationBar: _buildBottomBar(),
+      ),
+    );
+  }
+
+  Widget _buildScanInput(String placeholder) {
+    return Container(
+      height: 44,
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      decoration: const BoxDecoration(color: Colors.white),
+      child: TextField(
+        controller: _controller,
+        focusNode: _focusNode,
+        textInputAction: TextInputAction.done,
+        keyboardType: TextInputType.text,
+        onSubmitted: (value) {
+          _bloc.add(ExceptionPerformScanEvent(value));
+        },
+        decoration: InputDecoration(
+          hintText: placeholder,
+          hintStyle: const TextStyle(color: Colors.grey, fontSize: 14),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: BorderSide.none,
+          ),
+          filled: true,
+          fillColor: Colors.grey[200],
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoCard(ExceptionCollectionState state) {
+    final trayNo = state.trayNo.isEmpty ? '-' : state.trayNo;
+    final storeSite = state.storeSite.isEmpty ? '-' : state.storeSite;
+    final matCode = state.matCode.isEmpty
+        ? (state.barcodeContent?.matcode ?? '')
+        : state.matCode;
+    final batchNo = state.batchNo.isEmpty
+        ? (state.barcodeContent?.batchno ?? '')
+        : state.batchNo;
+    final sn = state.sn.isEmpty ? (state.barcodeContent?.sn ?? '') : state.sn;
+    final qty = state.collectQty == 0 ? '' : state.collectQty.toString();
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.vertical(bottom: Radius.circular(8)),
+      ),
+      child: Column(
+        children: [
+          _buildInfoRow('托盘号：', trayNo, '库位编码：', storeSite),
+          _buildDottedDivider(),
+          _buildInfoRow('物料：', matCode, '库存：', '-'),
+          _buildDottedDivider(),
+          _buildInfoRow('批次：', batchNo, '序列：', sn),
+          _buildDottedDivider(),
+          _buildInfoRow('采集数量：', qty, '异常类型：', state.exceptionName),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDataGrid(ExceptionCollectionState state) {
+    return CommonDataGrid<ExceptionCollectionItem>(
+      columns: _buildColumns(),
+      datas: state.items,
+      allowPager: false,
+      allowSelect: true,
+      currentPage: 1,
+      totalPages: 1,
+      onLoadData: (_) async {},
+      selectedRows: _selectedIndices(state.items, state.selectedIds),
+      onSelectionChanged: (indices) {
+        _handleSelectionChanged(indices, state.items);
+      },
+    );
+  }
+
+  List<GridColumnConfig<ExceptionCollectionItem>> _buildColumns() {
+    return [
+      GridColumnConfig<ExceptionCollectionItem>(
+        name: 'matCode',
+        headerText: '物料编码',
+        valueGetter: (row) => row.matCode,
+      ),
+      GridColumnConfig<ExceptionCollectionItem>(
+        name: 'storeSite',
+        headerText: '库位',
+        valueGetter: (row) => row.storeSite,
+      ),
+      GridColumnConfig<ExceptionCollectionItem>(
+        name: 'exceptionName',
+        headerText: '异常类型',
+        valueGetter: (row) => row.exceptionName,
+      ),
+      GridColumnConfig<ExceptionCollectionItem>(
+        name: 'qty',
+        headerText: '已采数',
+        valueGetter: (row) => row.qty,
+      ),
+      GridColumnConfig<ExceptionCollectionItem>(
+        name: 'batchNo',
+        headerText: '批号',
+        valueGetter: (row) => row.batchNo,
+      ),
+      GridColumnConfig<ExceptionCollectionItem>(
+        name: 'sn',
+        headerText: '序列号',
+        valueGetter: (row) => row.sn,
+      ),
+      GridColumnConfig<ExceptionCollectionItem>(
+        name: 'storeRoom',
+        headerText: '库房',
+        valueGetter: (row) => row.storeRoom,
+      ),
+      GridColumnConfig<ExceptionCollectionItem>(
+        name: 'proType',
+        headerText: '类型',
+        valueGetter: (row) => row.proType,
+      ),
+      GridColumnConfig<ExceptionCollectionItem>(
+        name: 'taskId',
+        headerText: '任务ID',
+        valueGetter: (row) => row.taskId,
+      ),
+    ];
+  }
+
+  List<int> _selectedIndices(
+    List<ExceptionCollectionItem> items,
+    List<String> selectedIds,
+  ) {
+    final idSet = selectedIds.toSet();
+    final indices = <int>[];
+    for (var i = 0; i < items.length; i++) {
+      if (idSet.contains(items[i].id)) {
+        indices.add(i);
+      }
+    }
+    return indices;
+  }
+
+  void _handleSelectionChanged(
+    List<int> indices,
+    List<ExceptionCollectionItem> items,
+  ) {
+    final ids = indices.map((index) => items[index].id).toList();
+    _bloc.add(ExceptionSelectionChangedEvent(ids));
+  }
+
+  Widget _buildBottomBar() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: const BoxDecoration(color: Colors.white),
+      child: Row(
+        children: [
+          Expanded(
+            child: OutlinedButton(
+              onPressed: _showExceptionTypeSelector,
+              style: OutlinedButton.styleFrom(
+                foregroundColor: const Color(0xFF1976D2),
+                side: const BorderSide(color: Color(0xFF1976D2)),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              child: const Text('异常类型'),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: OutlinedButton(
+              onPressed: () => _bloc.add(const ExceptionDeleteSelectedEvent()),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: const Color(0xFFE55D52),
+                side: const BorderSide(color: Color(0xFFE55D52)),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              child: const Text('删除'),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: ElevatedButton(
+              onPressed: _handleCommit,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF1976D2),
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              child: const Text('提交'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showExceptionTypeSelector() async {
+    final currentType = _bloc.state.exceptionType;
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (context) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: _exceptionOptions.map((option) {
+            final selected = option.value == currentType;
+            return ListTile(
+              title: Text(option.label),
+              trailing:
+                  selected ? const Icon(Icons.check, color: Color(0xFF1976D2)) : null,
+              onTap: () {
+                _bloc.add(
+                  ExceptionTypeChangedEvent(
+                    type: option.value,
+                    name: option.label,
+                  ),
+                );
+                Navigator.of(context).pop();
+              },
+            );
+          }).toList(),
+        );
+      },
+    );
+  }
+
+  Future<void> _handleCommit() async {
+    final state = _bloc.state;
+    if (state.stocks.isEmpty) {
+      _showErrorDialog('本次采集明细，请确认！');
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('提交确认'),
+        content: const Text('请确认是否提交？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('取消'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('确认'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      _bloc.add(const ExceptionCommitRequestedEvent());
+    }
+  }
+
+  Future<bool> _confirmLeaveIfNeeded() async {
+    final state = _bloc.state;
+    if (state.stocks.isEmpty) {
+      return true;
+    }
+
+    final shouldLeave = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('提示'),
+        content: const Text('当前采集记录尚未提交 确定退出采集吗？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('取消'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('确认'),
+          ),
+        ],
+      ),
+    );
+
+    return shouldLeave ?? false;
+  }
+
+  Widget _buildInfoRow(
+    String label1,
+    String value1,
+    String label2,
+    String value2,
+  ) {
+    const infoStyle = TextStyle(fontSize: 14, fontWeight: FontWeight.w400);
+    return SizedBox(
+      height: 32,
+      child: Row(
+        children: [
+          Expanded(
+            child: Row(
+              children: [
+                Container(
+                  width: 4,
+                  height: 10,
+                  margin: const EdgeInsets.only(right: 4),
+                  decoration: BoxDecoration(
+                    color: Colors.blue,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+                Text(label1, style: infoStyle),
+                const SizedBox(width: 2),
+                Expanded(
+                  child: Text(
+                    value1,
+                    style: infoStyle,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Row(
+              children: [
+                Container(
+                  width: 4,
+                  height: 10,
+                  margin: const EdgeInsets.only(right: 4),
+                  decoration: BoxDecoration(
+                    color: Colors.blue,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+                Text(label2, style: infoStyle),
+                const SizedBox(width: 2),
+                Expanded(
+                  child: Text(
+                    value2,
+                    style: infoStyle,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDottedDivider() {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final boxWidth = constraints.constrainWidth();
+        const dashWidth = 5.0;
+        const dashSpace = 3.0;
+        final dashCount = (boxWidth / (dashWidth + dashSpace)).floor();
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: List.generate(dashCount, (_) {
+            return const SizedBox(
+              width: dashWidth,
+              height: 1,
+              child: DecoratedBox(
+                decoration: BoxDecoration(color: Color(0xFF0067FC)),
+              ),
+            );
+          }),
+        );
+      },
+    );
+  }
+
+  void _showErrorDialog(String message) {
+    LoadingDialogManager.instance.showErrorDialog(context, message);
+  }
+}

--- a/wms_app_flutter/lib/modules/outbound/exception_collection/models/exception_collection_args.dart
+++ b/wms_app_flutter/lib/modules/outbound/exception_collection/models/exception_collection_args.dart
@@ -1,0 +1,13 @@
+import 'package:wms_app/modules/outbound/task_list/models/outbound_task.dart';
+
+class ExceptionCollectionArgs {
+  final OutboundTask task;
+  final String? trayNo;
+  final String? storeSite;
+
+  const ExceptionCollectionArgs({
+    required this.task,
+    this.trayNo,
+    this.storeSite,
+  });
+}

--- a/wms_app_flutter/lib/modules/outbound/exception_collection/models/exception_collection_models.dart
+++ b/wms_app_flutter/lib/modules/outbound/exception_collection/models/exception_collection_models.dart
@@ -1,0 +1,160 @@
+import 'package:uuid/uuid.dart';
+
+/// 异常采集列表行数据
+class ExceptionCollectionItem {
+  final String id;
+  final String matCode;
+  final String storeSite;
+  final String exceptionName;
+  final double qty;
+  final String batchNo;
+  final String sn;
+  final String storeRoom;
+  final String proType;
+  final String taskId;
+
+  const ExceptionCollectionItem({
+    required this.id,
+    required this.matCode,
+    required this.storeSite,
+    required this.exceptionName,
+    required this.qty,
+    required this.batchNo,
+    required this.sn,
+    required this.storeRoom,
+    required this.proType,
+    required this.taskId,
+  });
+
+  ExceptionCollectionItem copyWith({
+    String? id,
+    String? matCode,
+    String? storeSite,
+    String? exceptionName,
+    double? qty,
+    String? batchNo,
+    String? sn,
+    String? storeRoom,
+    String? proType,
+    String? taskId,
+  }) {
+    return ExceptionCollectionItem(
+      id: id ?? this.id,
+      matCode: matCode ?? this.matCode,
+      storeSite: storeSite ?? this.storeSite,
+      exceptionName: exceptionName ?? this.exceptionName,
+      qty: qty ?? this.qty,
+      batchNo: batchNo ?? this.batchNo,
+      sn: sn ?? this.sn,
+      storeRoom: storeRoom ?? this.storeRoom,
+      proType: proType ?? this.proType,
+      taskId: taskId ?? this.taskId,
+    );
+  }
+
+  static ExceptionCollectionItem create({
+    required String matCode,
+    required String storeSite,
+    required String exceptionName,
+    required double qty,
+    required String batchNo,
+    required String sn,
+    required String storeRoom,
+    required String proType,
+    required String taskId,
+  }) {
+    return ExceptionCollectionItem(
+      id: const Uuid().v4(),
+      matCode: matCode,
+      storeSite: storeSite,
+      exceptionName: exceptionName,
+      qty: qty,
+      batchNo: batchNo,
+      sn: sn,
+      storeRoom: storeRoom,
+      proType: proType,
+      taskId: taskId,
+    );
+  }
+}
+
+/// 提交异常采集的明细
+class ExceptionStock {
+  final String id;
+  final String matCode;
+  final String batchNo;
+  final String sn;
+  final double taskQty;
+  final double collectQty;
+  final String storeRoom;
+  final String storeSite;
+  final String taskId;
+  final String exceptionType;
+
+  const ExceptionStock({
+    required this.id,
+    required this.matCode,
+    required this.batchNo,
+    required this.sn,
+    required this.taskQty,
+    required this.collectQty,
+    required this.storeRoom,
+    required this.storeSite,
+    required this.taskId,
+    required this.exceptionType,
+  });
+
+  Map<String, dynamic> toPayload({
+    required String taskNo,
+    required String proType,
+    required String proofNo,
+  }) {
+    return {
+      'taskNo': taskNo,
+      'matCode': matCode,
+      'batchNo': batchNo,
+      'sn': sn,
+      'taskQty': taskQty,
+      'collectQty': collectQty,
+      'storeRoomNo': storeRoom,
+      'storeSiteNo': storeSite,
+      'taskid': taskId,
+      'excepttype': exceptionType,
+      'protype': proType,
+      'proofNo': proofNo,
+    };
+  }
+
+  ExceptionStock copyWith({
+    String? id,
+    String? matCode,
+    String? batchNo,
+    String? sn,
+    double? taskQty,
+    double? collectQty,
+    String? storeRoom,
+    String? storeSite,
+    String? taskId,
+    String? exceptionType,
+  }) {
+    return ExceptionStock(
+      id: id ?? this.id,
+      matCode: matCode ?? this.matCode,
+      batchNo: batchNo ?? this.batchNo,
+      sn: sn ?? this.sn,
+      taskQty: taskQty ?? this.taskQty,
+      collectQty: collectQty ?? this.collectQty,
+      storeRoom: storeRoom ?? this.storeRoom,
+      storeSite: storeSite ?? this.storeSite,
+      taskId: taskId ?? this.taskId,
+      exceptionType: exceptionType ?? this.exceptionType,
+    );
+  }
+}
+
+class ExceptionTypeOption {
+  final String value;
+  final String label;
+
+  const ExceptionTypeOption({required this.value, required this.label});
+}

--- a/wms_app_flutter/lib/modules/outbound/outbound_module.dart
+++ b/wms_app_flutter/lib/modules/outbound/outbound_module.dart
@@ -7,6 +7,9 @@ import 'package:wms_app/app_module.dart';
 import 'package:wms_app/modules/outbound/collection_task/bloc/collection_bloc.dart';
 import 'package:wms_app/modules/outbound/collection_task/outbound_collection_page.dart';
 import 'package:wms_app/modules/outbound/collection_task/services/collection_service.dart';
+import 'package:wms_app/modules/outbound/exception_collection/bloc/exception_collection_bloc.dart';
+import 'package:wms_app/modules/outbound/exception_collection/exception_collection_page.dart';
+import 'package:wms_app/modules/outbound/exception_collection/models/exception_collection_args.dart';
 import 'package:wms_app/modules/outbound/task_receive/bloc/receive_task_bloc.dart';
 import 'package:wms_app/modules/outbound/task_receive/bloc/receive_task_detail_bloc.dart';
 import 'package:wms_app/modules/outbound/task_receive/receive_task_detail_page.dart';
@@ -55,6 +58,9 @@ class OutboundModule extends Module {
 
     // 注册出库采集BLoC
     i.add<CollectionBloc>(() => CollectionBloc(i.get<CollectionService>()));
+    i.add<ExceptionCollectionBloc>(
+      () => ExceptionCollectionBloc(i.get<CollectionService>()),
+    );
 
     i.add<ReceiveTaskBloc>(
       () => ReceiveTaskBloc(
@@ -155,6 +161,34 @@ class OutboundModule extends Module {
         return BlocProvider(
           create: (context) => Modular.get<ReceiveTaskDetailBloc>(),
           child: ReceiveTaskDetailPage(task: task),
+        );
+      },
+    );
+
+    r.child(
+      '/exception',
+      child: (context) {
+        final data = Modular.args.data;
+        ExceptionCollectionArgs args;
+        if (data is ExceptionCollectionArgs) {
+          args = data;
+        } else if (data is Map) {
+          final task = data['task'] as OutboundTask?;
+          if (task == null) {
+            throw ArgumentError('缺少异常采集任务数据');
+          }
+          args = ExceptionCollectionArgs(
+            task: task,
+            trayNo: data['trayNo'] as String?,
+            storeSite: data['storeSite'] as String?,
+          );
+        } else {
+          throw ArgumentError('缺少异常采集参数');
+        }
+
+        return BlocProvider(
+          create: (context) => Modular.get<ExceptionCollectionBloc>(),
+          child: ExceptionCollectionPage(args: args),
         );
       },
     );


### PR DESCRIPTION
## Summary
- add an outbound exception collection bloc, models, and page that mirrors the UniApp workflow and UI
- expose pallet lookup and exception submission helpers in the collection service and register the new route in the outbound module
- hook the collection page “异常采集” entry to launch the Flutter implementation

## Testing
- not run (flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68defdb1e6b8833098bbe3172d02bf05