### PR TITLE
fix: align floor inbound scanning and receive flows

### DIFF
--- a/wms_app_flutter/lib/app_module.dart
+++ b/wms_app_flutter/lib/app_module.dart
@@ -9,6 +9,7 @@ import 'package:wms_app/services/api_service.dart';
 import 'modules/outbound/outbound_module.dart';
 import 'modules/feature_placeholder/feature_placeholder_bloc.dart';
 import 'modules/feature_placeholder/feature_placeholder_module.dart';
+import 'modules/floor_inbound/floor_inbound_module.dart';
 
 /// 应用主模块
 class AppModule extends Module {
@@ -73,19 +74,7 @@ class AppModule extends Module {
       ),
     );
 
-    r.module(
-      '/floor-inbound',
-      module: FeaturePlaceholderModule(
-        info: const FeaturePlaceholderInfo(
-          title: '平库入库',
-          description: '平库入库模块正在迁移至Flutter，敬请期待。',
-          todoItems: [
-            '梳理入库任务与采集接口',
-            '复用出库模块的分页、筛选及扫码架构',
-          ],
-        ),
-      ),
-    );
+    r.module('/floor-inbound', module: FloorInboundModule());
 
     r.module(
       '/online-picking',

--- a/wms_app_flutter/lib/modules/floor_inbound/collection_task/bloc/inbound_collection_bloc.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/collection_task/bloc/inbound_collection_bloc.dart
@@ -1,0 +1,633 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/bloc/inbound_collection_event.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/bloc/inbound_collection_state.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/models/inbound_collection_models.dart';
+import 'package:wms_app/modules/floor_inbound/services/floor_inbound_service.dart';
+import 'package:wms_app/modules/floor_inbound/task_details/models/inbound_task_item.dart';
+
+class InboundCollectionBloc extends Bloc<InboundCollectionEvent, InboundCollectionState> {
+  InboundCollectionBloc(this._service) : super(const InboundCollectionState()) {
+    on<InitializeInboundCollection>(_onInitialize);
+    on<InboundScanPerformed>(_onScan);
+    on<InboundManualQuantityConfirmed>(_onManualQuantityConfirmed);
+    on<InboundRemoveRecord>(_onRemoveRecord);
+    on<SubmitInboundCollection>(_onSubmit);
+  }
+
+  final FloorInboundService _service;
+
+  Future<void> _onInitialize(
+    InitializeInboundCollection event,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        isLoading: true,
+        task: event.task,
+        errorMessage: null,
+        infoMessage: null,
+      ),
+    );
+    try {
+      final query = InboundCollectionQuery(
+        inTaskNo: event.task.inTaskNo,
+        inTaskId: event.task.inTaskId,
+        storeRoomNo: event.task.storeRoomNo,
+        workStation: event.task.workStation,
+        forceSite: event.task.forceSite,
+        forceBatch: event.task.batchFlag,
+        taskComment: event.task.voucherNo,
+        userId: event.userId.toString(),
+      );
+
+      final detailList = await _service.getCollectionDetail(query);
+      emit(
+        state.copyWith(
+          isLoading: false,
+          context: InboundCollectionContext(
+            taskItems: detailList,
+            currentStep: InboundScanStep.site,
+          ),
+        ),
+      );
+    } catch (e) {
+      emit(
+        state.copyWith(
+          isLoading: false,
+          errorMessage: e.toString(),
+        ),
+      );
+    }
+  }
+
+  Future<void> _onScan(
+    InboundScanPerformed event,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final ctx = state.context;
+    if (ctx == null) return;
+    switch (ctx.currentStep) {
+      case InboundScanStep.site:
+        await _handleSiteScan(event.content, emit);
+        break;
+      case InboundScanStep.material:
+        await _handleMaterialScan(event.content, emit);
+        break;
+      case InboundScanStep.hazardProduction:
+        await _handleHazardProductionScan(event.content, emit);
+        break;
+      case InboundScanStep.hazardExpiry:
+        await _handleHazardExpiryScan(event.content, emit);
+        break;
+      case InboundScanStep.quantity:
+        final qty = double.tryParse(event.content);
+        if (qty == null || qty <= 0) {
+          emit(state.copyWith(errorMessage: '数量条码无效'));
+          return;
+        }
+        await _confirmQuantity(qty, emit);
+        break;
+    }
+  }
+
+  Future<void> _onManualQuantityConfirmed(
+    InboundManualQuantityConfirmed event,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    await _confirmQuantity(event.quantity, emit);
+  }
+
+  Future<void> _confirmQuantity(double quantity, Emitter<InboundCollectionState> emit) async {
+    final ctx = state.context;
+    final task = state.task;
+    if (ctx == null || ctx.currentTaskItem == null || ctx.currentSite == null || task == null) {
+      emit(state.copyWith(errorMessage: '请先扫描库位与物料'));
+      return;
+    }
+
+    final taskItem = ctx.currentTaskItem!;
+    final site = ctx.currentSite!;
+    final materialInfo = ctx.materialInfo;
+    final seqCtrl = materialInfo?.seqCtrl?.trim();
+    final sn = (materialInfo?.sn?.trim().isNotEmpty ?? false)
+        ? materialInfo!.sn!.trim()
+        : taskItem.sn?.trim();
+
+    if (seqCtrl == '0') {
+      if (sn == null || sn.isEmpty) {
+        emit(state.copyWith(errorMessage: '序列号物料必须提供序列号'));
+        return;
+      }
+      if (quantity != 1) {
+        emit(state.copyWith(errorMessage: '序列号物料数量必须为1'));
+        return;
+      }
+      final serialKey = '${taskItem.matCode}@$sn';
+      if (ctx.cache.serialNumbers.contains(serialKey)) {
+        emit(state.copyWith(errorMessage: '物料 ${taskItem.matCode} 序列号【$sn】不允许重复采集'));
+        return;
+      }
+    }
+
+    if (materialInfo?.isHazard == true) {
+      if (materialInfo?.productionDate == null) {
+        emit(state.copyWith(errorMessage: '危化品需要先录入生产日期'));
+        return;
+      }
+      if (materialInfo?.validDays == null) {
+        emit(state.copyWith(errorMessage: '危化品需要先录入有效期天数'));
+        return;
+      }
+    }
+
+    final existingInCache = _sumCacheQuantity(taskItem.itemId, ctx);
+    final alreadyCollected = taskItem.collectedQty + existingInCache;
+    final remainingPlan = taskItem.planQty - alreadyCollected;
+    if (remainingPlan <= 0) {
+      emit(state.copyWith(errorMessage: '物料 ${taskItem.matCode} 已完成采集'));
+      return;
+    }
+    if (quantity > remainingPlan) {
+      emit(state.copyWith(errorMessage: '本次采集数量超过计划剩余数量 $remainingPlan'));
+      return;
+    }
+
+    emit(state.copyWith(isLoading: true, errorMessage: null, infoMessage: null));
+    try {
+      double availableQty = ctx.availableQty;
+      if (availableQty <= 0) {
+        availableQty = await _fetchInventory(site, taskItem.matCode);
+      }
+
+      if (availableQty <= 0) {
+        throw Exception('库位【$site】未查询到物料【${taskItem.matCode}】库存');
+      }
+      if (quantity > availableQty) {
+        throw Exception('库位【$site】仅剩库存 $availableQty，无法采集 $quantity');
+      }
+
+      final batchNo = (materialInfo?.batchNo?.isNotEmpty ?? false)
+          ? materialInfo!.batchNo!
+          : taskItem.batchNo;
+
+      final record = InboundCollectionRecord(
+        itemId: taskItem.itemId,
+        inTaskId: taskItem.inTaskId,
+        storeSiteNo: site,
+        matCode: taskItem.matCode,
+        matName: taskItem.matName,
+        batchNo: batchNo,
+        quantity: quantity,
+        sn: sn,
+        supplierName: materialInfo?.supplierName ?? taskItem.supplierName,
+        subInventoryCode: materialInfo?.subInventoryCode ?? taskItem.subInventoryCode,
+        productionDate: materialInfo?.productionDate,
+        validDays: materialInfo?.validDays,
+      );
+
+      final updatedRecords = List<InboundCollectionRecord>.from(ctx.cache.records)
+        ..add(record);
+      final updatedItems = ctx.taskItems.map((item) {
+        if (item.itemId == taskItem.itemId) {
+          return item.copyWith(collectedQty: item.collectedQty + quantity);
+        }
+        return item;
+      }).toList();
+
+      final updatedSerials = Set<String>.from(ctx.cache.serialNumbers);
+      if (seqCtrl == '0' && (sn?.isNotEmpty ?? false)) {
+        updatedSerials.add('${taskItem.matCode}@$sn');
+      }
+
+      final remainingInventory = availableQty - quantity;
+
+      emit(
+        state.copyWith(
+          isLoading: false,
+          context: ctx.copyWith(
+            taskItems: updatedItems,
+            cache: ctx.cache
+                .copyWith(records: updatedRecords, serialNumbers: updatedSerials),
+            currentStep: InboundScanStep.site,
+            currentTaskItem: null,
+            currentSite: null,
+            currentBarcode: null,
+            materialInfo: null,
+            clearMaterialInfo: true,
+            availableQty: remainingInventory > 0 ? remainingInventory : 0,
+          ),
+          infoMessage: '已采集 ${record.matCode} 数量 $quantity',
+        ),
+      );
+    } catch (e) {
+      emit(state.copyWith(isLoading: false, errorMessage: e.toString()));
+    }
+  }
+
+  Future<void> _handleHazardProductionScan(
+    String raw,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final ctx = state.context;
+    if (ctx == null || ctx.materialInfo == null) {
+      emit(state.copyWith(errorMessage: '请先扫描危化品物料条码'));
+      return;
+    }
+
+    final date = _parseDateInput(raw);
+    if (date == null) {
+      emit(state.copyWith(errorMessage: '生产日期格式不正确，示例：2024-01-01'));
+      return;
+    }
+
+    final updatedInfo = ctx.materialInfo!.copyWith(productionDate: date);
+    final nextStep = updatedInfo.validDays == null
+        ? InboundScanStep.hazardExpiry
+        : InboundScanStep.quantity;
+
+    final updatedContext = ctx.copyWith(
+      materialInfo: updatedInfo,
+      currentStep: nextStep,
+    );
+
+    emit(
+      state.copyWith(
+        context: updatedContext,
+        infoMessage: nextStep == InboundScanStep.quantity
+            ? '危化品信息已补全，请录入数量'
+            : '生产日期已录入，请继续录入有效期天数',
+      ),
+    );
+
+    if ((updatedInfo.seqCtrl ?? '').trim() == '0' &&
+        nextStep == InboundScanStep.quantity) {
+      await _confirmQuantity(1, emit);
+    }
+  }
+
+  Future<void> _handleHazardExpiryScan(
+    String raw,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final ctx = state.context;
+    if (ctx == null || ctx.materialInfo == null) {
+      emit(state.copyWith(errorMessage: '请先扫描危化品物料条码'));
+      return;
+    }
+
+    final trimmed = raw.trim();
+    final days = int.tryParse(trimmed);
+    if (days == null || days <= 0) {
+      emit(state.copyWith(errorMessage: '有效期天数必须为正整数'));
+      return;
+    }
+
+    final updatedInfo = ctx.materialInfo!.copyWith(validDays: days);
+    final updatedContext = ctx.copyWith(
+      materialInfo: updatedInfo,
+      currentStep: InboundScanStep.quantity,
+    );
+
+    emit(
+      state.copyWith(
+        context: updatedContext,
+        infoMessage: '有效期已录入，请录入数量',
+      ),
+    );
+
+    if ((updatedInfo.seqCtrl ?? '').trim() == '0') {
+      await _confirmQuantity(1, emit);
+    }
+  }
+
+  Future<void> _onRemoveRecord(
+    InboundRemoveRecord event,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final ctx = state.context;
+    if (ctx == null) return;
+    if (event.recordIndex < 0 || event.recordIndex >= ctx.cache.records.length) {
+      return;
+    }
+    final record = ctx.cache.records[event.recordIndex];
+    final updated = List<InboundCollectionRecord>.from(ctx.cache.records)
+      ..removeAt(event.recordIndex);
+    final updatedItems = ctx.taskItems.map((item) {
+      if (item.itemId == record.itemId) {
+        final newCollected = item.collectedQty - record.quantity;
+        return item.copyWith(collectedQty: newCollected < 0 ? 0 : newCollected);
+      }
+      return item;
+    }).toList();
+
+    final updatedSerials = Set<String>.from(ctx.cache.serialNumbers);
+    if ((record.sn ?? '').isNotEmpty) {
+      updatedSerials.remove('${record.matCode}@${record.sn}');
+    }
+
+    emit(
+      state.copyWith(
+        context: ctx.copyWith(
+          taskItems: updatedItems,
+          cache: ctx.cache.copyWith(records: updated, serialNumbers: updatedSerials),
+        ),
+        infoMessage: '已删除 ${record.matCode} 数量 ${record.quantity}',
+      ),
+    );
+  }
+
+  Future<void> _onSubmit(
+    SubmitInboundCollection event,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final ctx = state.context;
+    final task = state.task;
+    if (ctx == null || task == null) {
+      return;
+    }
+    if (ctx.cache.records.isEmpty) {
+      emit(state.copyWith(errorMessage: '没有可提交的采集记录'));
+      return;
+    }
+    emit(state.copyWith(isLoading: true));
+    try {
+      final upShelvesInfos = ctx.cache.records.map((record) {
+        return {
+          'intaskno': task.inTaskNo,
+          'intaskid': task.inTaskId,
+          'storesite': record.storeSiteNo,
+          'matcode': record.matCode,
+          'matname': record.matName,
+          'batchno': record.batchNo,
+          'qty': record.quantity,
+          if (record.sn != null) 'sn': record.sn,
+          if (record.subInventoryCode != null) 'subinventorycode': record.subInventoryCode,
+        };
+      }).toList();
+      final itemInfos = ctx.cache.records.map((record) {
+        return {
+          'intaskitemid': record.itemId,
+          'qty': record.quantity,
+        };
+      }).toList();
+      final filter = ctx.cache.records
+          .where((record) => record.sn != null && record.sn!.isNotEmpty)
+          .map((record) => record.sn!)
+          .join(',');
+      await _service.submitCollection(
+        upShelvesInfos: upShelvesInfos,
+        itemListInfos: itemInfos,
+        serialFilter: filter,
+      );
+      emit(
+        state.copyWith(
+          isLoading: false,
+          context: ctx.copyWith(cache: const InboundCollectionCache()),
+          infoMessage: '提交成功',
+        ),
+      );
+    } catch (e) {
+      emit(state.copyWith(isLoading: false, errorMessage: e.toString()));
+    }
+  }
+
+  Future<void> _handleSiteScan(
+    String raw,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final site = _extractSiteCode(raw);
+    if (site == null || site.isEmpty) {
+      emit(state.copyWith(errorMessage: '无效的库位条码'));
+      return;
+    }
+
+    final task = state.task;
+    final ctx = state.context;
+    if (task == null || ctx == null) {
+      return;
+    }
+
+    emit(state.copyWith(isLoading: true, errorMessage: null, infoMessage: null));
+    try {
+      final response = await _service.getStoreSite(
+        storeRoomNo: task.storeRoomNo,
+        storeSiteNo: site,
+      );
+      final code = response['code']?.toString();
+      if (code != '200') {
+        throw Exception(response['msg']?.toString() ?? '库位验证失败');
+      }
+
+      final data = response['data'];
+      if (data is! List || data.isEmpty) {
+        throw Exception('库房【${task.storeRoomNo}】下无库位号【$site】');
+      }
+
+      final first = Map<String, dynamic>.from(data.first as Map);
+      if (first['isfrozen']?.toString() != '0') {
+        throw Exception('库位【$site】被锁定或者冻结');
+      }
+
+      emit(
+        state.copyWith(
+          isLoading: false,
+          context: ctx.copyWith(
+            currentSite: site,
+            currentStep: InboundScanStep.material,
+            currentTaskItem: null,
+            currentBarcode: null,
+            materialInfo: null,
+            clearMaterialInfo: true,
+            availableQty: 0,
+          ),
+          infoMessage: '库位 $site 已识别，请扫码物料',
+        ),
+      );
+    } catch (e) {
+      emit(state.copyWith(isLoading: false, errorMessage: e.toString()));
+    }
+  }
+
+  Future<void> _handleMaterialScan(
+    String raw,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final ctx = state.context;
+    if (ctx == null) return;
+
+    final barcode = raw.trim();
+    if (barcode.isEmpty) {
+      emit(state.copyWith(errorMessage: '无效的物料条码'));
+      return;
+    }
+
+    if ((ctx.currentSite ?? '').isEmpty) {
+      emit(state.copyWith(errorMessage: '请先扫描库位'));
+      return;
+    }
+
+    emit(state.copyWith(isLoading: true, errorMessage: null, infoMessage: null));
+    try {
+      final materialInfo = await _service.getMaterialInfo(barcode);
+      final matCode = materialInfo.matCode.trim();
+      if (matCode.isEmpty) {
+        throw Exception('无法识别物料条码');
+      }
+
+      final target = _matchTaskItem(
+        ctx.taskItems,
+        matCode,
+        materialInfo.batchNo?.trim(),
+        materialInfo.sn?.trim(),
+        materialInfo.seqCtrl,
+      );
+
+      final availableQty = await _fetchInventory(ctx.currentSite!, target.matCode);
+
+      InboundScanStep nextStep = InboundScanStep.quantity;
+      if (materialInfo.isHazard && materialInfo.productionDate == null) {
+        nextStep = InboundScanStep.hazardProduction;
+      } else if (materialInfo.isHazard && materialInfo.validDays == null) {
+        nextStep = InboundScanStep.hazardExpiry;
+      }
+
+      final updatedContext = ctx.copyWith(
+        currentBarcode: barcode,
+        currentTaskItem: target,
+        currentStep: nextStep,
+        materialInfo: materialInfo,
+        availableQty: availableQty,
+      );
+
+      emit(
+        state.copyWith(
+          isLoading: false,
+          context: updatedContext,
+          infoMessage: _buildMaterialRecognisedMessage(materialInfo, target, nextStep),
+        ),
+      );
+
+      final seqCtrl = materialInfo.seqCtrl?.trim();
+      if (seqCtrl == '0' && nextStep == InboundScanStep.quantity) {
+        await _confirmQuantity(1, emit);
+      }
+    } catch (e) {
+      emit(state.copyWith(isLoading: false, errorMessage: e.toString()));
+    }
+  }
+
+
+  InboundTaskItem _matchTaskItem(
+    List<InboundTaskItem> items,
+    String matCode,
+    String? batchNo,
+    String? sn,
+    String? seqCtrl,
+  ) {
+    final normalized = matCode.trim();
+    final serialCtrl = seqCtrl?.trim();
+
+    if (serialCtrl == '0' && sn != null && sn.isNotEmpty) {
+      try {
+        return items.firstWhere(
+          (item) =>
+              item.matCode == normalized &&
+              ((item.sn?.isEmpty ?? true) || item.sn == sn),
+        );
+      } catch (_) {
+        // fall back to batch matching
+      }
+    }
+
+    if (batchNo != null && batchNo.isNotEmpty) {
+      try {
+        return items.firstWhere(
+          (item) =>
+              item.matCode == normalized &&
+              (item.batchNo.isEmpty || item.batchNo == batchNo),
+        );
+      } catch (_) {
+        // fall back to mat code only
+      }
+    }
+
+    return items.firstWhere(
+      (item) => item.matCode == normalized,
+      orElse: () => throw Exception('物料$normalized不在任务明细中'),
+    );
+  }
+
+  String _buildMaterialRecognisedMessage(
+    InboundBarcodeContent info,
+    InboundTaskItem item,
+    InboundScanStep step,
+  ) {
+    if (step == InboundScanStep.hazardProduction) {
+      return '物料 ${item.matCode}(${item.matName}) 为危化品，请录入生产日期';
+    }
+    if (step == InboundScanStep.hazardExpiry) {
+      return '物料 ${item.matCode}(${item.matName}) 为危化品，请录入有效期天数';
+    }
+    if ((info.seqCtrl ?? '').trim() == '0') {
+      return '物料 ${item.matCode}(${item.matName}) 为序列管理，将自动采集数量1';
+    }
+    return '物料 ${item.matCode}(${item.matName}) 已识别，请录入数量';
+  }
+
+  String? _extractSiteCode(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) {
+      return null;
+    }
+    if (trimmed.contains(r'$KW$')) {
+      final parts = trimmed.split(r'$');
+      if (parts.length > 2 && parts[2].isNotEmpty) {
+        return parts[2];
+      }
+      return null;
+    }
+    return trimmed;
+  }
+
+  DateTime? _parseDateInput(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) return null;
+    final normalized = trimmed.contains('-')
+        ? trimmed
+        : trimmed.length == 8
+            ? '${trimmed.substring(0, 4)}-${trimmed.substring(4, 6)}-${trimmed.substring(6)}'
+            : trimmed;
+    return DateTime.tryParse(normalized);
+  }
+
+  double _sumCacheQuantity(String itemId, InboundCollectionContext ctx) {
+    return ctx.cache.records
+        .where((record) => record.itemId == itemId)
+        .fold<double>(0, (sum, record) => sum + record.quantity);
+  }
+
+  Future<double> _fetchInventory(String storeSite, String matCode) async {
+    final response = await _service.getInventoryBySite(
+      storeSite: storeSite,
+      matCode: matCode,
+    );
+
+    final code = response['code']?.toString();
+    if (code != '200') {
+      throw Exception(response['msg']?.toString() ?? '获取库存失败');
+    }
+
+    final data = response['data'];
+    if (data is List) {
+      double total = 0;
+      for (final item in data) {
+        if (item is Map) {
+          total += double.tryParse(item['repqty']?.toString() ?? '') ?? 0;
+        }
+      }
+      return total;
+    }
+
+    return 0;
+  }
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/collection_task/bloc/inbound_collection_event.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/collection_task/bloc/inbound_collection_event.dart
@@ -1,0 +1,50 @@
+import 'package:equatable/equatable.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/models/inbound_task.dart';
+
+abstract class InboundCollectionEvent extends Equatable {
+  const InboundCollectionEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class InitializeInboundCollection extends InboundCollectionEvent {
+  const InitializeInboundCollection({required this.task, required this.userId});
+
+  final InboundTask task;
+  final int userId;
+
+  @override
+  List<Object?> get props => [task, userId];
+}
+
+class InboundScanPerformed extends InboundCollectionEvent {
+  const InboundScanPerformed(this.content);
+
+  final String content;
+
+  @override
+  List<Object?> get props => [content];
+}
+
+class InboundManualQuantityConfirmed extends InboundCollectionEvent {
+  const InboundManualQuantityConfirmed(this.quantity);
+
+  final double quantity;
+
+  @override
+  List<Object?> get props => [quantity];
+}
+
+class InboundRemoveRecord extends InboundCollectionEvent {
+  const InboundRemoveRecord(this.recordIndex);
+
+  final int recordIndex;
+
+  @override
+  List<Object?> get props => [recordIndex];
+}
+
+class SubmitInboundCollection extends InboundCollectionEvent {
+  const SubmitInboundCollection();
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/collection_task/bloc/inbound_collection_state.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/collection_task/bloc/inbound_collection_state.dart
@@ -1,0 +1,38 @@
+import 'package:equatable/equatable.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/models/inbound_collection_models.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/models/inbound_task.dart';
+
+class InboundCollectionState extends Equatable {
+  const InboundCollectionState({
+    this.task,
+    this.context,
+    this.isLoading = false,
+    this.errorMessage,
+    this.infoMessage,
+  });
+
+  final InboundTask? task;
+  final InboundCollectionContext? context;
+  final bool isLoading;
+  final String? errorMessage;
+  final String? infoMessage;
+
+  InboundCollectionState copyWith({
+    InboundTask? task,
+    InboundCollectionContext? context,
+    bool? isLoading,
+    String? errorMessage,
+    String? infoMessage,
+  }) {
+    return InboundCollectionState(
+      task: task ?? this.task,
+      context: context ?? this.context,
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: errorMessage,
+      infoMessage: infoMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [task, context, isLoading, errorMessage, infoMessage];
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/collection_task/inbound_collection_page.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/collection_task/inbound_collection_page.dart
@@ -1,0 +1,252 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/bloc/inbound_collection_bloc.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/bloc/inbound_collection_event.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/bloc/inbound_collection_state.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/models/inbound_collection_models.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/models/inbound_task.dart';
+import 'package:wms_app/services/scanner_service.dart';
+
+class InboundCollectionPage extends StatefulWidget {
+  const InboundCollectionPage({super.key, required this.task, required this.userId});
+
+  final InboundTask task;
+  final int userId;
+
+  @override
+  State<InboundCollectionPage> createState() => _InboundCollectionPageState();
+}
+
+class _InboundCollectionPageState extends State<InboundCollectionPage> {
+  late final InboundCollectionBloc _bloc;
+  final TextEditingController _qtyController = TextEditingController();
+  final TextEditingController _scanController = TextEditingController();
+  StreamSubscription<String>? _scanSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<InboundCollectionBloc>(context);
+    _bloc.add(InitializeInboundCollection(task: widget.task, userId: widget.userId));
+
+    _scanSubscription = ScannerService.instance.stream.listen(
+      (code) {
+        if (!mounted) return;
+        if (!(ModalRoute.of(context)?.isCurrent ?? false)) return;
+        final trimmed = code.trim();
+        if (trimmed.isEmpty) return;
+        _bloc.add(InboundScanPerformed(trimmed));
+      },
+      onError: (error, __) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('扫码异常：$error')),
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _qtyController.dispose();
+    _scanController.dispose();
+    _scanSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar(title: '上架采集-${widget.task.inTaskNo}').appBar,
+      body: BlocConsumer<InboundCollectionBloc, InboundCollectionState>(
+        listener: (context, state) {
+          if (state.isLoading) {
+            LoadingDialogManager.instance.showLoadingDialog(context);
+          } else {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+          }
+          if (state.errorMessage != null) {
+            LoadingDialogManager.instance.showErrorDialog(context, state.errorMessage!);
+          }
+          if (state.infoMessage != null) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(state.infoMessage!)),
+            );
+          }
+        },
+        builder: (context, state) {
+          final ctx = state.context;
+          return Column(
+            children: [
+              _buildScanPanel(),
+              _buildStepIndicator(ctx),
+              if (ctx != null) _buildCurrentTarget(ctx),
+              _buildQuantityInput(ctx),
+              const Divider(height: 1),
+              Expanded(child: _buildRecordList(ctx)),
+              _buildSubmitBar(ctx),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildStepIndicator(InboundCollectionContext? ctx) {
+    final current = ctx?.currentStep ?? InboundScanStep.site;
+    String description;
+    switch (current) {
+      case InboundScanStep.site:
+        description = '请先扫描库位条码';
+        break;
+      case InboundScanStep.material:
+        description = '库位已识别，请扫描物料条码';
+        break;
+      case InboundScanStep.hazardProduction:
+        description = '危化品物料，需要录入生产日期（YYYY-MM-DD）';
+        break;
+      case InboundScanStep.hazardExpiry:
+        description = '危化品物料，需要录入有效期天数';
+        break;
+      case InboundScanStep.quantity:
+        description = '物料已识别，请录入数量';
+        break;
+    }
+    final stepOrder = {
+      InboundScanStep.site: 1,
+      InboundScanStep.material: 2,
+      InboundScanStep.hazardProduction: 3,
+      InboundScanStep.hazardExpiry: 4,
+      InboundScanStep.quantity: 5,
+    }[current]!;
+    final totalSteps = (ctx?.materialInfo?.isHazard ?? false) ? 5 : 3;
+    return ListTile(
+      title: Text(description, style: const TextStyle(fontWeight: FontWeight.bold)),
+      subtitle: Text('步骤：$stepOrder/$totalSteps'),
+    );
+  }
+
+  Widget _buildScanPanel() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _scanController,
+              decoration: const InputDecoration(
+                hintText: '扫描或输入条码后回车',
+              ),
+              onSubmitted: (value) {
+                if (value.isNotEmpty) {
+                  _bloc.add(InboundScanPerformed(value));
+                  _scanController.clear();
+                }
+              },
+            ),
+          ),
+          const SizedBox(width: 12),
+          ElevatedButton(
+            onPressed: () {
+              final text = _scanController.text.trim();
+              if (text.isNotEmpty) {
+                _bloc.add(InboundScanPerformed(text));
+                _scanController.clear();
+              }
+            },
+            child: const Text('确认'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCurrentTarget(InboundCollectionContext ctx) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('当前库位: ${ctx.currentSite ?? '-'}'),
+          Text('当前物料: ${ctx.currentTaskItem?.matCode ?? '-'} ${ctx.currentTaskItem?.matName ?? ''}'),
+          Text('计划数量: ${ctx.currentTaskItem?.planQty ?? 0} 已采集: ${ctx.currentTaskItem?.collectedQty ?? 0}'),
+          Text('库位可用库存: ${ctx.availableQty.toStringAsFixed(2)}'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildQuantityInput(InboundCollectionContext? ctx) {
+    final showInput = ctx?.currentStep == InboundScanStep.quantity;
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 200),
+      child: showInput
+          ? Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _qtyController,
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      decoration: const InputDecoration(labelText: '输入数量'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  ElevatedButton(
+                    onPressed: () {
+                      final qty = double.tryParse(_qtyController.text.trim());
+                      if (qty != null && qty > 0) {
+                        _bloc.add(InboundManualQuantityConfirmed(qty));
+                        _qtyController.clear();
+                      }
+                    },
+                    child: const Text('确认'),
+                  ),
+                ],
+              ),
+            )
+          : const SizedBox.shrink(),
+    );
+  }
+
+  Widget _buildRecordList(InboundCollectionContext? ctx) {
+    final records = ctx?.cache.records ?? const <InboundCollectionRecord>[];
+    if (records.isEmpty) {
+      return const Center(child: Text('暂无采集记录'));
+    }
+    return ListView.separated(
+      itemCount: records.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final record = records[index];
+        return ListTile(
+          title: Text('${record.matCode} - ${record.matName}'),
+          subtitle: Text('库位:${record.storeSiteNo} 批次:${record.batchNo} 数量:${record.quantity}'),
+          trailing: IconButton(
+            icon: const Icon(Icons.delete, color: Colors.redAccent),
+            onPressed: () => _bloc.add(InboundRemoveRecord(index)),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSubmitBar(InboundCollectionContext? ctx) {
+    final hasRecords = (ctx?.cache.records ?? const []).isNotEmpty;
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ElevatedButton.icon(
+          icon: const Icon(Icons.cloud_upload),
+          label: const Text('提交上架结果'),
+          onPressed: hasRecords ? () => _bloc.add(const SubmitInboundCollection()) : null,
+        ),
+      ),
+    );
+  }
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/collection_task/models/inbound_collection_models.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/collection_task/models/inbound_collection_models.dart
@@ -1,0 +1,337 @@
+import 'package:equatable/equatable.dart';
+import 'package:wms_app/modules/floor_inbound/task_details/models/inbound_task_item.dart';
+
+enum InboundScanStep {
+  site,
+  material,
+  hazardProduction,
+  hazardExpiry,
+  quantity,
+}
+
+class InboundBarcodeContent extends Equatable {
+  const InboundBarcodeContent({
+    required this.matCode,
+    this.matName,
+    this.batchNo,
+    this.sn,
+    this.seqCtrl,
+    this.idOld,
+    this.qty,
+    this.dgFlag,
+    this.productionDate,
+    this.validDays,
+    this.supplierName,
+    this.subInventoryCode,
+  });
+
+  factory InboundBarcodeContent.fromJson(Map<String, dynamic> json) {
+    DateTime? productionDate;
+    final pdate = json['pdate']?.toString();
+    if (pdate != null && pdate.isNotEmpty) {
+      productionDate = DateTime.tryParse(pdate);
+    }
+
+    int? validDays;
+    final vdays = json['vdays']?.toString();
+    if (vdays != null && vdays.isNotEmpty) {
+      validDays = int.tryParse(vdays);
+    }
+
+    return InboundBarcodeContent(
+      matCode: json['matcode']?.toString() ?? '',
+      matName: json['matname']?.toString(),
+      batchNo: json['batchno']?.toString(),
+      sn: json['sn']?.toString(),
+      seqCtrl: json['seqctrl']?.toString(),
+      idOld: json['id_old']?.toString(),
+      qty: double.tryParse(json['qty']?.toString() ?? ''),
+      dgFlag: json['dgFlg']?.toString(),
+      productionDate: productionDate,
+      validDays: validDays,
+      supplierName: json['suppliername']?.toString(),
+      subInventoryCode: json['subinventoryCode']?.toString(),
+    );
+  }
+
+  final String matCode;
+  final String? matName;
+  final String? batchNo;
+  final String? sn;
+  final String? seqCtrl;
+  final String? idOld;
+  final double? qty;
+  final String? dgFlag;
+  final DateTime? productionDate;
+  final int? validDays;
+  final String? supplierName;
+  final String? subInventoryCode;
+
+  bool get isHazard => (dgFlag ?? '').toUpperCase() == 'Y';
+
+  InboundBarcodeContent copyWith({
+    DateTime? productionDate,
+    bool clearProductionDate = false,
+    int? validDays,
+    bool clearValidDays = false,
+  }) {
+    return InboundBarcodeContent(
+      matCode: matCode,
+      matName: matName,
+      batchNo: batchNo,
+      sn: sn,
+      seqCtrl: seqCtrl,
+      idOld: idOld,
+      qty: qty,
+      dgFlag: dgFlag,
+      productionDate: clearProductionDate
+          ? null
+          : (productionDate ?? this.productionDate),
+      validDays: clearValidDays ? null : (validDays ?? this.validDays),
+      supplierName: supplierName,
+      subInventoryCode: subInventoryCode,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        matCode,
+        matName,
+        batchNo,
+        sn,
+        seqCtrl,
+        idOld,
+        qty,
+        dgFlag,
+        productionDate,
+        validDays,
+        supplierName,
+        subInventoryCode,
+      ];
+}
+
+class InboundCollectionRecord extends Equatable {
+  const InboundCollectionRecord({
+    required this.itemId,
+    required this.inTaskId,
+    required this.storeSiteNo,
+    required this.matCode,
+    required this.matName,
+    required this.batchNo,
+    required this.quantity,
+    this.sn,
+    this.supplierName,
+    this.subInventoryCode,
+    this.productionDate,
+    this.validDays,
+  });
+
+  final String itemId;
+  final String inTaskId;
+  final String storeSiteNo;
+  final String matCode;
+  final String matName;
+  final String batchNo;
+  final double quantity;
+  final String? sn;
+  final String? supplierName;
+  final String? subInventoryCode;
+  final DateTime? productionDate;
+  final int? validDays;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'intaskitemid': itemId,
+      'intaskid': inTaskId,
+      'storeSite': storeSiteNo,
+      'matCode': matCode,
+      'matName': matName,
+      'batchNo': batchNo,
+      'qty': quantity,
+      if (sn != null) 'sn': sn,
+      if (supplierName != null) 'supplierName': supplierName,
+      if (subInventoryCode != null) 'subinventoryCode': subInventoryCode,
+      if (productionDate != null) 'data1': _formatDate(productionDate!),
+      if (validDays != null) 'data2': validDays,
+    };
+  }
+
+  static String _formatDate(DateTime date) {
+    return '${date.year.toString().padLeft(4, '0')}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  List<Object?> get props => [
+        itemId,
+        inTaskId,
+        storeSiteNo,
+        matCode,
+        matName,
+        batchNo,
+        quantity,
+        sn,
+        supplierName,
+        subInventoryCode,
+        productionDate,
+        validDays,
+      ];
+}
+
+class InboundCollectionCache extends Equatable {
+  const InboundCollectionCache({
+    this.records = const [],
+    this.step = InboundScanStep.site,
+    this.serialNumbers = const <String>{},
+  });
+
+  final List<InboundCollectionRecord> records;
+  final InboundScanStep step;
+  final Set<String> serialNumbers;
+
+  InboundCollectionCache copyWith({
+    List<InboundCollectionRecord>? records,
+    InboundScanStep? step,
+    Set<String>? serialNumbers,
+  }) {
+    return InboundCollectionCache(
+      records: records ?? this.records,
+      step: step ?? this.step,
+      serialNumbers: serialNumbers ?? this.serialNumbers,
+    );
+  }
+
+  @override
+  List<Object?> get props {
+    final serialList = serialNumbers.toList()..sort();
+    return [records, step, serialList];
+  }
+}
+
+class InboundCollectionContext extends Equatable {
+  const InboundCollectionContext({
+    required this.taskItems,
+    required this.currentStep,
+    this.currentSite,
+    this.currentTaskItem,
+    this.currentBarcode,
+    this.inputQty,
+    this.availableQty = 0,
+    this.materialInfo,
+    this.cache = const InboundCollectionCache(),
+  });
+
+  final List<InboundTaskItem> taskItems;
+  final InboundScanStep currentStep;
+  final String? currentSite;
+  final InboundTaskItem? currentTaskItem;
+  final String? currentBarcode;
+  final double? inputQty;
+  final double availableQty;
+  final InboundBarcodeContent? materialInfo;
+  final InboundCollectionCache cache;
+
+  InboundCollectionContext copyWith({
+    List<InboundTaskItem>? taskItems,
+    InboundScanStep? currentStep,
+    String? currentSite,
+    InboundTaskItem? currentTaskItem,
+    String? currentBarcode,
+    double? inputQty,
+    double? availableQty,
+    InboundBarcodeContent? materialInfo,
+    bool clearMaterialInfo = false,
+    InboundCollectionCache? cache,
+  }) {
+    return InboundCollectionContext(
+      taskItems: taskItems ?? this.taskItems,
+      currentStep: currentStep ?? this.currentStep,
+      currentSite: currentSite ?? this.currentSite,
+      currentTaskItem: currentTaskItem ?? this.currentTaskItem,
+      currentBarcode: currentBarcode ?? this.currentBarcode,
+      inputQty: inputQty ?? this.inputQty,
+      availableQty: availableQty ?? this.availableQty,
+      materialInfo: clearMaterialInfo ? null : (materialInfo ?? this.materialInfo),
+      cache: cache ?? this.cache,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        taskItems,
+        currentStep,
+        currentSite,
+        currentTaskItem,
+        currentBarcode,
+        inputQty,
+        availableQty,
+        materialInfo,
+        cache,
+      ];
+}
+
+class InboundCollectionQuery extends Equatable {
+  const InboundCollectionQuery({
+    required this.inTaskNo,
+    required this.inTaskId,
+    required this.storeRoomNo,
+    required this.workStation,
+    this.forceSite = '',
+    this.forceBatch = '',
+    this.taskComment = '',
+    this.taskFinishFlag = '0',
+    this.roomTag = '0',
+    this.sortType = '',
+    this.sortColumn = '',
+    this.searchKey = '',
+    this.userId = '',
+  });
+
+  final String inTaskNo;
+  final String inTaskId;
+  final String storeRoomNo;
+  final String workStation;
+  final String forceSite;
+  final String forceBatch;
+  final String taskComment;
+  final String taskFinishFlag;
+  final String roomTag;
+  final String sortType;
+  final String sortColumn;
+  final String searchKey;
+  final String userId;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'intaskno': inTaskNo,
+      'intaskid': inTaskId,
+      'storeroomno': storeRoomNo,
+      'forcesite': forceSite,
+      'forcebatch': forceBatch,
+      'taskcomment': taskComment,
+      'taskFinishFlag': taskFinishFlag,
+      'roomtag': roomTag,
+      'workstation': workStation,
+      'sortType': sortType,
+      'sortColumn': sortColumn,
+      'searchKey': searchKey,
+      'userId': userId,
+    };
+  }
+
+  @override
+  List<Object?> get props => [
+        inTaskNo,
+        inTaskId,
+        storeRoomNo,
+        workStation,
+        forceSite,
+        forceBatch,
+        taskComment,
+        taskFinishFlag,
+        roomTag,
+        sortType,
+        sortColumn,
+        searchKey,
+        userId,
+      ];
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/floor_inbound_module.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/floor_inbound_module.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/app_module.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/bloc/inbound_collection_bloc.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/inbound_collection_page.dart';
+import 'package:wms_app/modules/floor_inbound/services/floor_inbound_service.dart';
+import 'package:wms_app/modules/floor_inbound/task_details/bloc/inbound_task_detail_bloc.dart';
+import 'package:wms_app/modules/floor_inbound/task_details/inbound_task_detail_page.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/bloc/inbound_task_bloc.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/inbound_task_list_page.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/models/inbound_task.dart';
+import 'package:wms_app/modules/floor_inbound/task_receive/receive_task_page.dart';
+import 'package:wms_app/services/dio_client.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+class FloorInboundModule extends Module {
+  @override
+  List<Module> get imports => [AppModule()];
+
+  @override
+  void binds(Injector i) {
+    i.addSingleton<FloorInboundService>(() => FloorInboundService(i.get<DioClient>().dio));
+
+    i.add<InboundTaskBloc>(
+      () => InboundTaskBloc(
+        service: i.get<FloorInboundService>(),
+        userManager: i.get<UserManager>(),
+      ),
+    );
+
+    i.add<InboundTaskDetailBloc>(
+      () => InboundTaskDetailBloc(i.get<FloorInboundService>()),
+    );
+
+    i.add<InboundCollectionBloc>(
+      () => InboundCollectionBloc(i.get<FloorInboundService>()),
+    );
+  }
+
+  @override
+  void routes(RouteManager r) {
+    r.child(
+      '/',
+      child: (context) => BlocProvider(
+        create: (_) => Modular.get<InboundTaskBloc>(),
+        child: const InboundTaskListPage(),
+      ),
+    );
+
+    r.child(
+      '/list',
+      child: (context) => BlocProvider(
+        create: (_) => Modular.get<InboundTaskBloc>(),
+        child: const InboundTaskListPage(),
+      ),
+    );
+
+    r.child(
+      '/detail/:inTaskId',
+      child: (context) {
+        final args = Modular.args;
+        final task = args.data['task'] as InboundTask;
+        final workStation = args.data['workStation'] as String? ?? task.workStation;
+        final receiveMode = args.data['receiveMode'] as bool? ?? false;
+        return BlocProvider(
+          create: (_) => Modular.get<InboundTaskDetailBloc>(),
+          child: InboundTaskDetailPage(
+            task: task,
+            workStation: workStation,
+            receiveMode: receiveMode,
+          ),
+        );
+      },
+    );
+
+    r.child(
+      '/collect/:inTaskNo',
+      child: (context) {
+        final args = Modular.args;
+        final task = args.data['task'] as InboundTask;
+        final userId = Modular.get<UserManager>().userInfo?.userId ?? 0;
+        return BlocProvider(
+          create: (_) => Modular.get<InboundCollectionBloc>(),
+          child: InboundCollectionPage(task: task, userId: userId),
+        );
+      },
+    );
+
+    r.child(
+      '/receive',
+      child: (context) => BlocProvider(
+        create: (_) => Modular.get<InboundTaskBloc>(),
+        child: const InboundReceiveTaskPage(),
+      ),
+    );
+  }
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/services/floor_inbound_service.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/services/floor_inbound_service.dart
@@ -1,0 +1,150 @@
+import 'package:dio/dio.dart';
+import 'package:wms_app/modules/floor_inbound/task_details/models/inbound_task_item.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/models/inbound_task.dart';
+import 'package:wms_app/modules/outbound/task_details/models/commit_task_item_result.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/models/inbound_collection_models.dart';
+import 'package:wms_app/services/api_response_handler.dart';
+
+class FloorInboundService {
+  FloorInboundService(this._dio);
+
+  final Dio _dio;
+
+  Future<InboundTaskListData> getTaskList(InboundTaskQuery query) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/intaskList',
+      queryParameters: query.toJson(),
+    );
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => InboundTaskListData.fromJson(data),
+    );
+  }
+
+  Future<InboundTaskItemListData> getTaskItems(InboundTaskItemQuery query) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/intaskitemList',
+      queryParameters: query.toJson(),
+    );
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => InboundTaskItemListData.fromJson(data),
+    );
+  }
+
+  Future<CommitTaskItemResult> commitTaskItems({
+    required List<String> taskItemIds,
+    String roomTag = '0',
+    bool isCancel = false,
+  }) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/system/terminal/commitRCInTaskItem',
+      data: {
+        'intaskitemids': taskItemIds,
+        'roomTag': roomTag,
+        'isCanel': isCancel.toString(),
+      },
+      options: Options(headers: {'content-type': 'application/json;charset=UTF-8'}),
+    );
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) =>
+          CommitTaskItemResult.fromJson(Map<String, dynamic>.from(data as Map)),
+    );
+  }
+
+  Future<Map<String, dynamic>> getStoreSite({
+    required String storeRoomNo,
+    required String storeSiteNo,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getStoreSite',
+      queryParameters: {
+        'storeRoomNo': storeRoomNo,
+        'storeSiteNo': storeSiteNo,
+      },
+    );
+
+    return response.data ?? <String, dynamic>{};
+  }
+
+  Future<Map<String, dynamic>> getInventoryBySite({
+    required String storeSite,
+    required String matCode,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getMtlRepertory',
+      queryParameters: {
+        'storeSite': storeSite,
+        'matCode': matCode,
+      },
+    );
+
+    return response.data ?? <String, dynamic>{};
+  }
+
+  Future<InboundBarcodeContent> getMaterialInfo(String qrContent) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/system/terminal/getPmMaterialInfoByQR',
+      data: {'qrContent': qrContent},
+    );
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => InboundBarcodeContent.fromJson(
+        Map<String, dynamic>.from(data as Map),
+      ),
+    );
+  }
+
+  Future<void> submitCollection({
+    required List<Map<String, dynamic>> upShelvesInfos,
+    required List<Map<String, dynamic>> itemListInfos,
+    required String serialFilter,
+  }) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/system/terminal/commitUp',
+      data: {
+        'upShelvesInfos': upShelvesInfos,
+        'itemListInfos': itemListInfos,
+        'filter': serialFilter,
+      },
+      options: Options(headers: {'content-type': 'application/json;charset=UTF-8'}),
+    );
+
+    ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => data,
+    );
+  }
+
+  Future<List<InboundTaskItem>> getCollectionDetail(
+    InboundCollectionQuery query,
+  ) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/intaskitemList',
+      queryParameters: query.toJson(),
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is Map<String, dynamic>) {
+          final rows = data['rows'] as List<dynamic>? ?? const [];
+          return rows
+              .map((e) => InboundTaskItem.fromJson(
+                  Map<String, dynamic>.from(e as Map<dynamic, dynamic>)))
+              .toList();
+        }
+
+        if (data is List) {
+          return data
+              .map((e) => InboundTaskItem.fromJson(
+                  Map<String, dynamic>.from(e as Map<dynamic, dynamic>)))
+              .toList();
+        }
+
+        return const <InboundTaskItem>[];
+      },
+    );
+  }
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_details/bloc/inbound_task_detail_bloc.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_details/bloc/inbound_task_detail_bloc.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wms_app/modules/floor_inbound/services/floor_inbound_service.dart';
+import 'package:wms_app/modules/outbound/task_details/models/commit_task_item_result.dart';
+
+import '../models/inbound_task_item.dart';
+import 'inbound_task_detail_event.dart';
+import 'inbound_task_detail_state.dart';
+
+class InboundTaskDetailBloc extends Bloc<InboundTaskDetailEvent, InboundTaskDetailState> {
+  InboundTaskDetailBloc(this._service) : super(const InboundTaskDetailState()) {
+    on<InitializeInboundTaskDetail>(_onInitialize);
+    on<SearchInboundTaskItems>(_onSearch);
+    on<ToggleInboundTaskItemSelection>(_onToggleSelection);
+    on<SelectAllInboundTaskItems>(_onSelectAll);
+    on<CommitInboundTaskItems>(_onCommit);
+    on<RefreshInboundTaskItems>(_onRefresh);
+  }
+
+  final FloorInboundService _service;
+
+  Future<void> _onInitialize(
+    InitializeInboundTaskDetail event,
+    Emitter<InboundTaskDetailState> emit,
+  ) async {
+    final query = InboundTaskItemQuery(
+      inTaskId: event.inTaskId,
+      workStation: event.workStation,
+    );
+    emit(state.copyWith(query: query, selectedIds: {}));
+    await _load(query, emit);
+  }
+
+  Future<void> _onSearch(
+    SearchInboundTaskItems event,
+    Emitter<InboundTaskDetailState> emit,
+  ) async {
+    final currentQuery = state.query;
+    if (currentQuery == null) return;
+    try {
+      final keyword = event.decode
+          ? await _resolveSearchKeyword(event.keyword)
+          : event.keyword.trim();
+      final query = currentQuery.copyWith(searchKey: keyword, pageIndex: 0);
+      emit(state.copyWith(query: query, errorMessage: null));
+      await _load(query, emit);
+    } catch (e) {
+      emit(state.copyWith(errorMessage: e.toString()));
+    }
+  }
+
+  Future<void> _onRefresh(
+    RefreshInboundTaskItems event,
+    Emitter<InboundTaskDetailState> emit,
+  ) async {
+    final query = state.query;
+    if (query == null) return;
+    await _load(query, emit);
+  }
+
+  Future<void> _load(
+    InboundTaskItemQuery query,
+    Emitter<InboundTaskDetailState> emit,
+  ) async {
+    try {
+      emit(state.copyWith(isLoading: true, errorMessage: null));
+      final response = await _service.getTaskItems(query);
+      emit(
+        state.copyWith(
+          isLoading: false,
+          items: response.rows,
+          selectedIds: state.selectedIds.intersection(response.rows.map((e) => e.itemId).toSet()),
+        ),
+      );
+    } catch (e) {
+      emit(state.copyWith(isLoading: false, errorMessage: e.toString()));
+    }
+  }
+
+  Future<void> _onToggleSelection(
+    ToggleInboundTaskItemSelection event,
+    Emitter<InboundTaskDetailState> emit,
+  ) async {
+    final newSet = Set<String>.from(state.selectedIds);
+    if (newSet.contains(event.itemId)) {
+      newSet.remove(event.itemId);
+    } else {
+      newSet.add(event.itemId);
+    }
+    emit(state.copyWith(selectedIds: newSet));
+  }
+
+  Future<void> _onSelectAll(
+    SelectAllInboundTaskItems event,
+    Emitter<InboundTaskDetailState> emit,
+  ) async {
+    if (event.checked) {
+      emit(state.copyWith(selectedIds: state.items.map((e) => e.itemId).toSet()));
+    } else {
+      emit(state.copyWith(selectedIds: {}));
+    }
+  }
+
+  Future<void> _onCommit(
+    CommitInboundTaskItems event,
+    Emitter<InboundTaskDetailState> emit,
+  ) async {
+    if (state.selectedIds.isEmpty) {
+      return;
+    }
+    emit(state.copyWith(isLoading: true));
+    try {
+      final CommitTaskItemResult result = await _service.commitTaskItems(
+        taskItemIds: state.selectedIds.toList(),
+        isCancel: event.cancel,
+      );
+      emit(state.copyWith(isLoading: false));
+      if (result.success) {
+        final query = state.query;
+        if (query != null) {
+          await _load(query, emit);
+        }
+      } else {
+        emit(state.copyWith(errorMessage: '操作失败:${result.action}'));
+      }
+    } catch (e) {
+      emit(state.copyWith(isLoading: false, errorMessage: e.toString()));
+    }
+  }
+
+  Future<String> _resolveSearchKeyword(String raw) async {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) {
+      return '';
+    }
+    if (trimmed.contains(r'$KW$')) {
+      final parts = trimmed.split(r'$');
+      if (parts.length > 2 && parts[2].isNotEmpty) {
+        return parts[2];
+      }
+      throw Exception('库位条码解析失败');
+    }
+    if (trimmed.toUpperCase().contains('MC')) {
+      final info = await _service.getMaterialInfo(trimmed);
+      final matCode = info.matCode.trim();
+      if (matCode.isEmpty) {
+        throw Exception('物料二维码无法识别');
+      }
+      return matCode;
+    }
+    return trimmed;
+  }
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_details/bloc/inbound_task_detail_event.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_details/bloc/inbound_task_detail_event.dart
@@ -1,0 +1,59 @@
+import 'package:equatable/equatable.dart';
+
+class InboundTaskDetailEvent extends Equatable {
+  const InboundTaskDetailEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class InitializeInboundTaskDetail extends InboundTaskDetailEvent {
+  const InitializeInboundTaskDetail({required this.inTaskId, required this.workStation});
+
+  final String inTaskId;
+  final String workStation;
+
+  @override
+  List<Object?> get props => [inTaskId, workStation];
+}
+
+class SearchInboundTaskItems extends InboundTaskDetailEvent {
+  const SearchInboundTaskItems(this.keyword, {this.decode = false});
+
+  final String keyword;
+  final bool decode;
+
+  @override
+  List<Object?> get props => [keyword, decode];
+}
+
+class ToggleInboundTaskItemSelection extends InboundTaskDetailEvent {
+  const ToggleInboundTaskItemSelection(this.itemId);
+
+  final String itemId;
+
+  @override
+  List<Object?> get props => [itemId];
+}
+
+class SelectAllInboundTaskItems extends InboundTaskDetailEvent {
+  const SelectAllInboundTaskItems(this.checked);
+
+  final bool checked;
+
+  @override
+  List<Object?> get props => [checked];
+}
+
+class CommitInboundTaskItems extends InboundTaskDetailEvent {
+  const CommitInboundTaskItems({required this.cancel});
+
+  final bool cancel;
+
+  @override
+  List<Object?> get props => [cancel];
+}
+
+class RefreshInboundTaskItems extends InboundTaskDetailEvent {
+  const RefreshInboundTaskItems();
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_details/bloc/inbound_task_detail_state.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_details/bloc/inbound_task_detail_state.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+import 'package:wms_app/modules/floor_inbound/task_details/models/inbound_task_item.dart';
+
+class InboundTaskDetailState extends Equatable {
+  const InboundTaskDetailState({
+    this.isLoading = false,
+    this.items = const [],
+    this.selectedIds = const <String>{},
+    this.errorMessage,
+    this.query,
+  });
+
+  final bool isLoading;
+  final List<InboundTaskItem> items;
+  final Set<String> selectedIds;
+  final String? errorMessage;
+  final InboundTaskItemQuery? query;
+
+  InboundTaskDetailState copyWith({
+    bool? isLoading,
+    List<InboundTaskItem>? items,
+    Set<String>? selectedIds,
+    String? errorMessage,
+    InboundTaskItemQuery? query,
+  }) {
+    return InboundTaskDetailState(
+      isLoading: isLoading ?? this.isLoading,
+      items: items ?? this.items,
+      selectedIds: selectedIds ?? this.selectedIds,
+      errorMessage: errorMessage,
+      query: query ?? this.query,
+    );
+  }
+
+  @override
+  List<Object?> get props => [isLoading, items, selectedIds, errorMessage, query];
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_details/config/inbound_task_detail_grid_config.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_details/config/inbound_task_detail_grid_config.dart
@@ -1,0 +1,52 @@
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/modules/floor_inbound/task_details/models/inbound_task_item.dart';
+
+class InboundTaskDetailGridConfig {
+  static List<GridColumnConfig<InboundTaskItem>> buildColumns() {
+    return [
+      GridColumnConfig(
+        title: '任务明细ID',
+        width: 140,
+        valueGetter: (item) => item.itemId,
+      ),
+      GridColumnConfig(
+        title: '物料编码',
+        width: 160,
+        valueGetter: (item) => item.matCode,
+      ),
+      GridColumnConfig(
+        title: '物料名称',
+        width: 220,
+        valueGetter: (item) => item.matName,
+      ),
+      GridColumnConfig(
+        title: '库位',
+        width: 140,
+        valueGetter: (item) => item.storeSiteNo,
+      ),
+      GridColumnConfig(
+        title: '批次',
+        width: 140,
+        valueGetter: (item) => item.batchNo,
+      ),
+      GridColumnConfig(
+        title: '计划数量',
+        width: 120,
+        valueGetter: (item) => item.planQty.toStringAsFixed(2),
+        alignment: GridColumnAlignment.right,
+      ),
+      GridColumnConfig(
+        title: '已采集数量',
+        width: 120,
+        valueGetter: (item) => item.collectedQty.toStringAsFixed(2),
+        alignment: GridColumnAlignment.right,
+      ),
+      GridColumnConfig(
+        title: '库存数量',
+        width: 120,
+        valueGetter: (item) => item.inventoryQty.toStringAsFixed(2),
+        alignment: GridColumnAlignment.right,
+      ),
+    ];
+  }
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_details/inbound_task_detail_page.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_details/inbound_task_detail_page.dart
@@ -1,0 +1,196 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/modules/floor_inbound/task_details/bloc/inbound_task_detail_bloc.dart';
+import 'package:wms_app/modules/floor_inbound/task_details/bloc/inbound_task_detail_event.dart';
+import 'package:wms_app/modules/floor_inbound/task_details/bloc/inbound_task_detail_state.dart';
+import 'package:wms_app/modules/floor_inbound/task_details/models/inbound_task_item.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/models/inbound_task.dart';
+import 'package:wms_app/services/scanner_service.dart';
+
+class InboundTaskDetailPage extends StatefulWidget {
+  const InboundTaskDetailPage({
+    super.key,
+    required this.task,
+    required this.workStation,
+    this.receiveMode = false,
+  });
+
+  final InboundTask task;
+  final String workStation;
+  final bool receiveMode;
+
+  @override
+  State<InboundTaskDetailPage> createState() => _InboundTaskDetailPageState();
+}
+
+class _InboundTaskDetailPageState extends State<InboundTaskDetailPage> {
+  late final InboundTaskDetailBloc _bloc;
+  final TextEditingController _searchController = TextEditingController();
+  StreamSubscription<String>? _scanSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<InboundTaskDetailBloc>(context);
+    _bloc.add(
+      InitializeInboundTaskDetail(
+        inTaskId: widget.task.inTaskId,
+        workStation: widget.workStation,
+      ),
+    );
+
+    _scanSubscription = ScannerService.instance.stream.listen(
+      (code) {
+        if (!mounted) return;
+        if (!(ModalRoute.of(context)?.isCurrent ?? false)) return;
+        final trimmed = code.trim();
+        if (trimmed.isEmpty) return;
+        _searchController.text = trimmed;
+        _bloc.add(SearchInboundTaskItems(trimmed, decode: true));
+      },
+      onError: (error, __) {
+        if (!mounted) return;
+        LoadingDialogManager.instance.showErrorDialog(
+          context,
+          '扫码异常：$error',
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _scanSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar(title: '明细-${widget.task.inTaskNo}').appBar,
+      body: BlocConsumer<InboundTaskDetailBloc, InboundTaskDetailState>(
+        listener: (context, state) {
+          if (state.isLoading) {
+            LoadingDialogManager.instance.showLoadingDialog(context);
+          } else {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+          }
+          if (state.errorMessage != null) {
+            LoadingDialogManager.instance.showErrorDialog(context, state.errorMessage!);
+          }
+        },
+        builder: (context, state) {
+          return Column(
+            children: [
+              _buildSearchBar(),
+              _buildActionBar(state),
+              Expanded(
+                child: ListView.separated(
+                  itemCount: state.items.length,
+                  separatorBuilder: (_, __) => const Divider(height: 1),
+                  itemBuilder: (context, index) {
+                    final item = state.items[index];
+                    final checked = state.selectedIds.contains(item.itemId);
+                    return CheckboxListTile(
+                      value: checked,
+                      onChanged: (_) =>
+                          _bloc.add(ToggleInboundTaskItemSelection(item.itemId)),
+                      title: Text('${item.matCode} - ${item.matName}'),
+                      subtitle: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text('库位: ${item.storeSiteNo}   批次: ${item.batchNo}'),
+                          Text('计划: ${item.planQty}   已采集: ${item.collectedQty}   库存: ${item.inventoryQty}'),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSearchBar() {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      color: Colors.white,
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _searchController,
+              decoration: InputDecoration(
+                hintText: '扫描或输入物料/库位',
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: () => _bloc.add(
+                    SearchInboundTaskItems(
+                      _searchController.text.trim(),
+                      decode: true,
+                    ),
+                  ),
+                ),
+              ),
+              onSubmitted: (value) =>
+                  _bloc.add(SearchInboundTaskItems(value.trim(), decode: true)),
+            ),
+          ),
+          const SizedBox(width: 12),
+          ElevatedButton(
+            onPressed: () => _bloc.add(
+              SearchInboundTaskItems(
+                _searchController.text.trim(),
+                decode: true,
+              ),
+            ),
+            child: const Text('查询'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActionBar(InboundTaskDetailState state) {
+    final allSelected = state.selectedIds.length == state.items.length && state.items.isNotEmpty;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      color: Colors.grey[100],
+      child: Row(
+        children: [
+          Checkbox(
+            value: allSelected,
+            onChanged: (value) =>
+                _bloc.add(SelectAllInboundTaskItems(value ?? false)),
+          ),
+          const Text('全选'),
+          const Spacer(),
+          if (!widget.receiveMode) ...[
+            ElevatedButton(
+              onPressed: state.selectedIds.isEmpty
+                  ? null
+                  : () => _bloc.add(const CommitInboundTaskItems(cancel: true)),
+              style: ElevatedButton.styleFrom(backgroundColor: Colors.orange),
+              child: const Text('撤销'),
+            ),
+            const SizedBox(width: 12),
+          ],
+          ElevatedButton(
+            onPressed: state.selectedIds.isEmpty
+                ? null
+                : () => _bloc.add(const CommitInboundTaskItems(cancel: false)),
+            child: const Text('接收'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_details/models/inbound_task_item.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_details/models/inbound_task_item.dart
@@ -1,0 +1,183 @@
+import 'package:equatable/equatable.dart';
+
+class InboundTaskItem extends Equatable {
+  const InboundTaskItem({
+    required this.itemId,
+    required this.inTaskId,
+    required this.inTaskNo,
+    required this.matCode,
+    required this.matName,
+    required this.batchNo,
+    required this.storeSiteNo,
+    required this.storeRoomNo,
+    required this.planQty,
+    required this.collectedQty,
+    required this.inventoryQty,
+    this.sn,
+    this.subInventoryCode,
+    this.orderNo,
+    this.supplierName,
+    this.trayNo,
+  });
+
+  factory InboundTaskItem.fromJson(Map<String, dynamic> json) {
+    return InboundTaskItem(
+      itemId: (json['intaskitemid'] ?? json['itemId']).toString(),
+      inTaskId: (json['intaskid'] ?? json['inTaskId']).toString(),
+      inTaskNo: json['intaskno']?.toString() ?? '',
+      matCode: json['matcode']?.toString() ?? '',
+      matName: json['matname']?.toString() ?? '',
+      batchNo: json['batchno']?.toString() ?? '',
+      storeSiteNo: json['storesiteno']?.toString() ?? json['storeSite']?.toString() ?? '',
+      storeRoomNo: json['storeroomno']?.toString() ?? '',
+      planQty: double.tryParse(json['hintqty']?.toString() ?? '') ??
+          double.tryParse(json['planqty']?.toString() ?? '') ?? 0,
+      collectedQty: double.tryParse(json['collectedqty']?.toString() ?? '') ?? 0,
+      inventoryQty: double.tryParse(json['repqty']?.toString() ?? '') ?? 0,
+      sn: json['sn']?.toString(),
+      subInventoryCode: json['subinventorycode']?.toString(),
+      orderNo: json['orderno']?.toString(),
+      supplierName: json['parname']?.toString(),
+      trayNo: json['trayno']?.toString(),
+    );
+  }
+
+  final String itemId;
+  final String inTaskId;
+  final String inTaskNo;
+  final String matCode;
+  final String matName;
+  final String batchNo;
+  final String storeSiteNo;
+  final String storeRoomNo;
+  final double planQty;
+  final double collectedQty;
+  final double inventoryQty;
+  final String? sn;
+  final String? subInventoryCode;
+  final String? orderNo;
+  final String? supplierName;
+  final String? trayNo;
+
+  InboundTaskItem copyWith({
+    String? itemId,
+    String? inTaskId,
+    String? inTaskNo,
+    String? matCode,
+    String? matName,
+    String? batchNo,
+    String? storeSiteNo,
+    String? storeRoomNo,
+    double? planQty,
+    double? collectedQty,
+    double? inventoryQty,
+    String? sn,
+    String? subInventoryCode,
+    String? orderNo,
+    String? supplierName,
+    String? trayNo,
+  }) {
+    return InboundTaskItem(
+      itemId: itemId ?? this.itemId,
+      inTaskId: inTaskId ?? this.inTaskId,
+      inTaskNo: inTaskNo ?? this.inTaskNo,
+      matCode: matCode ?? this.matCode,
+      matName: matName ?? this.matName,
+      batchNo: batchNo ?? this.batchNo,
+      storeSiteNo: storeSiteNo ?? this.storeSiteNo,
+      storeRoomNo: storeRoomNo ?? this.storeRoomNo,
+      planQty: planQty ?? this.planQty,
+      collectedQty: collectedQty ?? this.collectedQty,
+      inventoryQty: inventoryQty ?? this.inventoryQty,
+      sn: sn ?? this.sn,
+      subInventoryCode: subInventoryCode ?? this.subInventoryCode,
+      orderNo: orderNo ?? this.orderNo,
+      supplierName: supplierName ?? this.supplierName,
+      trayNo: trayNo ?? this.trayNo,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        itemId,
+        inTaskId,
+        inTaskNo,
+        matCode,
+        matName,
+        batchNo,
+        storeSiteNo,
+        storeRoomNo,
+        planQty,
+        collectedQty,
+        inventoryQty,
+        sn,
+        subInventoryCode,
+        orderNo,
+        supplierName,
+        trayNo,
+      ];
+}
+
+class InboundTaskItemListData {
+  InboundTaskItemListData({required this.total, required this.rows});
+
+  factory InboundTaskItemListData.fromJson(Map<String, dynamic> json) {
+    final rows = (json['rows'] as List<dynamic>? ?? [])
+        .map((item) => InboundTaskItem.fromJson(item as Map<String, dynamic>))
+        .toList();
+    final total = json['total'] is int
+        ? json['total'] as int
+        : int.tryParse(json['total']?.toString() ?? '') ?? rows.length;
+    return InboundTaskItemListData(total: total, rows: rows);
+  }
+
+  final int total;
+  final List<InboundTaskItem> rows;
+}
+
+class InboundTaskItemQuery extends Equatable {
+  const InboundTaskItemQuery({
+    required this.inTaskId,
+    required this.workStation,
+    this.searchKey = '',
+    this.roomTag = '0',
+    this.pageIndex = 0,
+    this.pageSize = 100,
+  });
+
+  final String inTaskId;
+  final String workStation;
+  final String searchKey;
+  final String roomTag;
+  final int pageIndex;
+  final int pageSize;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'intaskid': inTaskId,
+      'workstation': workStation,
+      'searchKey': searchKey,
+      'roomTag': roomTag,
+      'PageIndex': (pageIndex + 1).toString(),
+      'PageSize': pageSize.toString(),
+    };
+  }
+
+  InboundTaskItemQuery copyWith({
+    String? searchKey,
+    int? pageIndex,
+    int? pageSize,
+  }) {
+    return InboundTaskItemQuery(
+      inTaskId: inTaskId,
+      workStation: workStation,
+      searchKey: searchKey ?? this.searchKey,
+      roomTag: roomTag,
+      pageIndex: pageIndex ?? this.pageIndex,
+      pageSize: pageSize ?? this.pageSize,
+    );
+  }
+
+  @override
+  List<Object?> get props => [inTaskId, workStation, searchKey, roomTag, pageIndex, pageSize];
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_list/bloc/inbound_task_bloc.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_list/bloc/inbound_task_bloc.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/models/inbound_task.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/bloc/inbound_task_event.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/bloc/inbound_task_state.dart';
+import 'package:wms_app/modules/floor_inbound/services/floor_inbound_service.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+class InboundTaskBloc extends Bloc<InboundTaskEvent, InboundTaskState> {
+  InboundTaskBloc({required FloorInboundService service, required UserManager userManager})
+      : _service = service,
+        _userManager = userManager,
+        super(const InboundTaskState()) {
+    currentQuery = _defaultQuery();
+    gridBloc = CommonDataGridBloc(dataLoader: _createDataLoader());
+
+    on<SearchInboundTasksEvent>(_onSearch);
+    on<FilterInboundTasksEvent>(_onFilter);
+    on<RefreshInboundTasksEvent>(_onRefresh);
+    on<SetInboundTaskUserScopeEvent>(_onSetUserScope);
+  }
+
+  final FloorInboundService _service;
+  final UserManager _userManager;
+  late final CommonDataGridBloc<InboundTask> gridBloc;
+  late InboundTaskQuery currentQuery;
+
+  InboundTaskQuery _defaultQuery() {
+    final user = _userManager.userInfo;
+    final userId = user?.userId.toString() ?? '';
+    return InboundTaskQuery(userId: userId, roleOrUserId: userId);
+  }
+
+  DataGridLoader<InboundTask> _createDataLoader() {
+    return (pageIndex) async {
+      final query = currentQuery.copyWith(pageIndex: pageIndex);
+      final response = await _service.getTaskList(query);
+      final totalPages = (response.total / query.pageSize).ceil();
+      return DataGridResponseData(
+        totalPages: totalPages <= 0 ? 1 : totalPages,
+        data: response.rows,
+      );
+    };
+  }
+
+  Future<void> _onSearch(
+    SearchInboundTasksEvent event,
+    Emitter<InboundTaskState> emit,
+  ) async {
+    currentQuery = currentQuery.copyWith(searchKey: event.searchKey, pageIndex: 0);
+    gridBloc.add(LoadDataEvent(0));
+  }
+
+  Future<void> _onFilter(
+    FilterInboundTasksEvent event,
+    Emitter<InboundTaskState> emit,
+  ) async {
+    emit(state.copyWith(finishFlag: event.finishFlag));
+    currentQuery = currentQuery.copyWith(finishFlag: event.finishFlag, pageIndex: 0);
+    final completer = Completer<DataGridResponseData<InboundTask>>();
+    gridBloc.add(LoadDataEvent(0, completer: completer));
+    await completer.future;
+  }
+
+  Future<void> _onRefresh(
+    RefreshInboundTasksEvent event,
+    Emitter<InboundTaskState> emit,
+  ) async {
+    gridBloc.add(LoadDataEvent(0));
+  }
+
+  Future<void> _onSetUserScope(
+    SetInboundTaskUserScopeEvent event,
+    Emitter<InboundTaskState> emit,
+  ) async {
+    currentQuery = currentQuery.copyWith(
+      userId: event.userId,
+      roleOrUserId: event.roleOrUserId,
+      pageIndex: 0,
+    );
+  }
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_list/bloc/inbound_task_event.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_list/bloc/inbound_task_event.dart
@@ -1,0 +1,40 @@
+import 'package:equatable/equatable.dart';
+
+abstract class InboundTaskEvent extends Equatable {
+  const InboundTaskEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class SearchInboundTasksEvent extends InboundTaskEvent {
+  const SearchInboundTasksEvent(this.searchKey);
+
+  final String searchKey;
+
+  @override
+  List<Object?> get props => [searchKey];
+}
+
+class FilterInboundTasksEvent extends InboundTaskEvent {
+  const FilterInboundTasksEvent(this.finishFlag);
+
+  final String finishFlag;
+
+  @override
+  List<Object?> get props => [finishFlag];
+}
+
+class RefreshInboundTasksEvent extends InboundTaskEvent {
+  const RefreshInboundTasksEvent();
+}
+
+class SetInboundTaskUserScopeEvent extends InboundTaskEvent {
+  const SetInboundTaskUserScopeEvent({required this.userId, required this.roleOrUserId});
+
+  final String userId;
+  final String roleOrUserId;
+
+  @override
+  List<Object?> get props => [userId, roleOrUserId];
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_list/bloc/inbound_task_state.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_list/bloc/inbound_task_state.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+
+class InboundTaskState extends Equatable {
+  const InboundTaskState({this.finishFlag = '0'});
+
+  final String finishFlag;
+
+  InboundTaskState copyWith({String? finishFlag}) {
+    return InboundTaskState(
+      finishFlag: finishFlag ?? this.finishFlag,
+    );
+  }
+
+  @override
+  List<Object?> get props => [finishFlag];
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_list/config/inbound_task_grid_config.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_list/config/inbound_task_grid_config.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+
+import '../models/inbound_task.dart';
+
+typedef InboundTaskOperation = void Function(
+    InboundTask task, InboundTaskOperationType type);
+
+enum InboundTaskOperationType { collect, detail }
+
+class InboundTaskGridConfig {
+  static List<GridColumnConfig<InboundTask>> buildColumns(
+    InboundTaskOperation onOperate, {
+    bool includeCollect = true,
+  }) {
+    return [
+      GridColumnConfig<InboundTask>(
+        name: 'operation',
+        headerText: '操作',
+        width: includeCollect ? 180 : 120,
+        valueGetter: (_) => '',
+        cellBuilder: (task, __, ___) {
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              if (includeCollect)
+                Padding(
+                  padding: const EdgeInsets.only(right: 8),
+                  child: _ActionButton(
+                    label: '采集',
+                    onPressed: () =>
+                        onOperate(task, InboundTaskOperationType.collect),
+                  ),
+                ),
+              _ActionButton(
+                label: '明细',
+                onPressed: () =>
+                    onOperate(task, InboundTaskOperationType.detail),
+              ),
+            ],
+          );
+        },
+      ),
+      GridColumnConfig<InboundTask>(
+        name: 'orderNo',
+        headerText: '入库单号',
+        width: 160,
+        valueGetter: (task) => task.orderNo,
+      ),
+      GridColumnConfig<InboundTask>(
+        name: 'sourceOrder',
+        headerText: '来源单号',
+        width: 160,
+        valueGetter: (task) => task.sourceOrderNo,
+      ),
+      GridColumnConfig<InboundTask>(
+        name: 'taskNo',
+        headerText: '任务号',
+        width: 160,
+        valueGetter: (task) => task.inTaskNo,
+      ),
+      GridColumnConfig<InboundTask>(
+        name: 'storeRoom',
+        headerText: '库房',
+        width: 120,
+        valueGetter: (task) => task.storeRoomNo,
+      ),
+      GridColumnConfig<InboundTask>(
+        name: 'workStation',
+        headerText: '工位',
+        width: 120,
+        valueGetter: (task) => task.workStation,
+      ),
+      GridColumnConfig<InboundTask>(
+        name: 'supplier',
+        headerText: '供应商',
+        width: 200,
+        valueGetter: (task) => task.supplierName,
+      ),
+      GridColumnConfig<InboundTask>(
+        name: 'voucher',
+        headerText: '凭证号',
+        width: 160,
+        valueGetter: (task) => task.voucherNo,
+      ),
+      GridColumnConfig<InboundTask>(
+        name: 'planQty',
+        headerText: '计划数量',
+        width: 120,
+        valueGetter: (task) => task.planQty,
+        formatter: (value, _) =>
+            (value is num) ? value.toStringAsFixed(2) : value.toString(),
+        textAlign: TextAlign.right,
+      ),
+      GridColumnConfig<InboundTask>(
+        name: 'finishQty',
+        headerText: '完成数量',
+        width: 120,
+        valueGetter: (task) => task.finishQty,
+        formatter: (value, _) =>
+            (value is num) ? value.toStringAsFixed(2) : value.toString(),
+        textAlign: TextAlign.right,
+      ),
+      GridColumnConfig<InboundTask>(
+        name: 'status',
+        headerText: '状态',
+        width: 120,
+        valueGetter: (task) => task.status,
+      ),
+    ];
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({required this.label, required this.onPressed});
+
+  final String label;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 32,
+      child: OutlinedButton(
+        onPressed: onPressed,
+        child: Text(label),
+      ),
+    );
+  }
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_list/inbound_task_list_page.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_list/inbound_task_list_page.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_state.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/bloc/inbound_task_bloc.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/bloc/inbound_task_event.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/config/inbound_task_grid_config.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/models/inbound_task.dart';
+import 'package:wms_app/services/scanner_service.dart';
+
+class InboundTaskListPage extends StatefulWidget {
+  const InboundTaskListPage({super.key});
+
+  @override
+  State<InboundTaskListPage> createState() => _InboundTaskListPageState();
+}
+
+class _InboundTaskListPageState extends State<InboundTaskListPage> {
+  late final InboundTaskBloc _bloc;
+  late final CommonDataGridBloc<InboundTask> _gridBloc;
+  final TextEditingController _scanController = TextEditingController();
+  StreamSubscription<String>? _scanSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<InboundTaskBloc>(context);
+    _gridBloc = _bloc.gridBloc;
+
+    _scanSubscription = ScannerService.instance.stream.listen(
+      (code) {
+        if (!mounted) return;
+        if (!(ModalRoute.of(context)?.isCurrent ?? false)) return;
+        final trimmed = code.trim();
+        if (trimmed.isEmpty) return;
+        _scanController.text = trimmed;
+        _bloc.add(SearchInboundTasksEvent(trimmed));
+      },
+      onError: (error, __) {
+        if (!mounted) return;
+        LoadingDialogManager.instance.showErrorDialog(
+          context,
+          '扫码异常：$error',
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _scanController.dispose();
+    _scanSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar(
+        title: '平库上架任务',
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh, color: Colors.white),
+            onPressed: () => _bloc.add(const RefreshInboundTasksEvent()),
+          ),
+          IconButton(
+            icon: const Icon(Icons.checklist_rtl, color: Colors.white),
+            onPressed: () => Modular.to.pushNamed('/floor-inbound/receive'),
+          ),
+        ],
+      ).appBar,
+      body: Column(
+        children: [
+          _buildSearchBar(),
+          Expanded(child: _buildGrid()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchBar() {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      color: Colors.white,
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _scanController,
+              decoration: InputDecoration(
+                hintText: '请扫描入库单号或任务号',
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.clear),
+                  onPressed: () {
+                    _scanController.clear();
+                    _bloc.add(const SearchInboundTasksEvent(''));
+                  },
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              onSubmitted: (value) =>
+                  _bloc.add(SearchInboundTasksEvent(value.trim())),
+            ),
+          ),
+          const SizedBox(width: 12),
+          ElevatedButton(
+            onPressed: () => _bloc.add(SearchInboundTasksEvent(_scanController.text.trim())),
+            child: const Text('查询'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildGrid() {
+    return BlocProvider.value(
+      value: _gridBloc,
+      child: BlocConsumer<CommonDataGridBloc<InboundTask>, CommonDataGridState<InboundTask>>(
+        listener: (context, state) {
+          if (state.status == GridStatus.loading) {
+            LoadingDialogManager.instance.showLoadingDialog(context);
+          } else {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+          }
+
+          if (state.status == GridStatus.error) {
+            LoadingDialogManager.instance.showErrorDialog(
+              context,
+              state.errorMessage ?? '加载任务列表失败',
+            );
+          }
+        },
+        builder: (context, state) {
+          return CommonDataGrid<InboundTask>(
+            columns: InboundTaskGridConfig.buildColumns(_onOperate),
+            data: state.data ?? const [],
+            selectedRows: state.selectedRows,
+            currentPage: state.currentPage,
+            totalPages: state.totalPages,
+            onLoadData: (pageIndex) async {
+              _gridBloc.add(LoadDataEvent(pageIndex));
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  void _onOperate(InboundTask task, InboundTaskOperationType type) {
+    if (type == InboundTaskOperationType.collect) {
+      Modular.to.pushNamed(
+        '/floor-inbound/collect/${task.inTaskNo}',
+        arguments: {'task': task},
+      );
+    } else {
+      Modular.to.pushNamed(
+        '/floor-inbound/detail/${task.inTaskId}',
+        arguments: {
+          'task': task,
+          'workStation': task.workStation,
+        },
+      );
+    }
+  }
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_list/models/inbound_task.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_list/models/inbound_task.dart
@@ -1,0 +1,181 @@
+import 'package:equatable/equatable.dart';
+
+/// 平库上架任务模型
+class InboundTask extends Equatable {
+  const InboundTask({
+    required this.inTaskId,
+    required this.inTaskNo,
+    required this.orderNo,
+    required this.sourceOrderNo,
+    required this.storeRoomNo,
+    required this.workStation,
+    required this.supplierName,
+    required this.voucherNo,
+    required this.batchFlag,
+    required this.forceSite,
+    required this.planQty,
+    required this.finishQty,
+    required this.status,
+    this.createdTime,
+  });
+
+  factory InboundTask.fromJson(Map<String, dynamic> json) {
+    return InboundTask(
+      inTaskId: (json['intaskid'] ?? json['inTaskId']).toString(),
+      inTaskNo: json['intaskno']?.toString() ?? '',
+      orderNo: json['data2']?.toString() ?? json['orderNo']?.toString() ?? '',
+      sourceOrderNo:
+          json['data3']?.toString() ?? json['sourceOrderNo']?.toString() ?? '',
+      storeRoomNo: json['storeroomno']?.toString() ?? '',
+      workStation: json['workstation']?.toString() ?? '',
+      supplierName: json['parname']?.toString() ?? json['supplierName']?.toString() ?? '',
+      voucherNo: json['taskcomment']?.toString() ?? '',
+      batchFlag: json['batchflag']?.toString() ?? json['batchFlag']?.toString() ?? 'N',
+      forceSite: json['forcesite']?.toString() ?? json['forceSite']?.toString() ?? 'N',
+      planQty: double.tryParse(json['planqty']?.toString() ?? '') ??
+          double.tryParse(json['taskqty']?.toString() ?? '') ?? 0,
+      finishQty: double.tryParse(json['finishqty']?.toString() ?? '') ?? 0,
+      status: json['status']?.toString() ?? '',
+      createdTime: json['createtime']?.toString(),
+    );
+  }
+
+  final String inTaskId;
+  final String inTaskNo;
+  final String orderNo;
+  final String sourceOrderNo;
+  final String storeRoomNo;
+  final String workStation;
+  final String supplierName;
+  final String voucherNo;
+  final String batchFlag;
+  final String forceSite;
+  final double planQty;
+  final double finishQty;
+  final String status;
+  final String? createdTime;
+
+  @override
+  List<Object?> get props => [
+        inTaskId,
+        inTaskNo,
+        orderNo,
+        sourceOrderNo,
+        storeRoomNo,
+        workStation,
+        supplierName,
+        voucherNo,
+        batchFlag,
+        forceSite,
+        planQty,
+        finishQty,
+        status,
+        createdTime,
+      ];
+}
+
+/// 平库上架任务列表响应
+class InboundTaskListData {
+  InboundTaskListData({required this.total, required this.rows});
+
+  factory InboundTaskListData.fromJson(Map<String, dynamic> json) {
+    final rows = (json['rows'] as List<dynamic>? ?? [])
+        .map((item) => InboundTask.fromJson(item as Map<String, dynamic>))
+        .toList();
+    final total = json['total'] is int
+        ? json['total'] as int
+        : int.tryParse(json['total']?.toString() ?? '') ?? rows.length;
+    return InboundTaskListData(total: total, rows: rows);
+  }
+
+  final int total;
+  final List<InboundTask> rows;
+}
+
+/// 平库上架任务列表查询参数
+class InboundTaskQuery extends Equatable {
+  const InboundTaskQuery({
+    this.sortType = '',
+    this.sortColumn = '',
+    this.searchKey = '',
+    required this.userId,
+    required this.roleOrUserId,
+    this.roomTag = '0',
+    this.transferType = '0',
+    this.finishFlag = '0',
+    this.beatFlag = 'N',
+    this.pageIndex = 0,
+    this.pageSize = 100,
+  });
+
+  final String sortType;
+  final String sortColumn;
+  final String searchKey;
+  final String userId;
+  final String roleOrUserId;
+  final String roomTag;
+  final String transferType;
+  final String finishFlag;
+  final String beatFlag;
+  final int pageIndex;
+  final int pageSize;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'sortType': sortType,
+      'sortColumn': sortColumn,
+      'searchKey': searchKey,
+      'userId': userId,
+      'roleoRuserId': roleOrUserId,
+      'roomTag': roomTag,
+      'transferType': transferType,
+      'beatflag': beatFlag,
+      'PageIndex': (pageIndex + 1).toString(),
+      'PageSize': pageSize.toString(),
+      'finishFlag': finishFlag,
+    };
+  }
+
+  InboundTaskQuery copyWith({
+    String? sortType,
+    String? sortColumn,
+    String? searchKey,
+    String? userId,
+    String? roleOrUserId,
+    String? roomTag,
+    String? transferType,
+    String? finishFlag,
+    String? beatFlag,
+    int? pageIndex,
+    int? pageSize,
+  }) {
+    return InboundTaskQuery(
+      sortType: sortType ?? this.sortType,
+      sortColumn: sortColumn ?? this.sortColumn,
+      searchKey: searchKey ?? this.searchKey,
+      userId: userId ?? this.userId,
+      roleOrUserId: roleOrUserId ?? this.roleOrUserId,
+      roomTag: roomTag ?? this.roomTag,
+      transferType: transferType ?? this.transferType,
+      finishFlag: finishFlag ?? this.finishFlag,
+      beatFlag: beatFlag ?? this.beatFlag,
+      pageIndex: pageIndex ?? this.pageIndex,
+      pageSize: pageSize ?? this.pageSize,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        sortType,
+        sortColumn,
+        searchKey,
+        userId,
+        roleOrUserId,
+        roomTag,
+        transferType,
+        finishFlag,
+        beatFlag,
+        pageIndex,
+        pageSize,
+      ];
+}

--- a/wms_app_flutter/lib/modules/floor_inbound/task_receive/receive_task_page.dart
+++ b/wms_app_flutter/lib/modules/floor_inbound/task_receive/receive_task_page.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_state.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/bloc/inbound_task_bloc.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/bloc/inbound_task_event.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/config/inbound_task_grid_config.dart';
+import 'package:wms_app/modules/floor_inbound/task_list/models/inbound_task.dart';
+import 'package:wms_app/services/scanner_service.dart';
+
+class InboundReceiveTaskPage extends StatefulWidget {
+  const InboundReceiveTaskPage({super.key});
+
+  @override
+  State<InboundReceiveTaskPage> createState() => _InboundReceiveTaskPageState();
+}
+
+class _InboundReceiveTaskPageState extends State<InboundReceiveTaskPage> {
+  late final InboundTaskBloc _bloc;
+  late final CommonDataGridBloc<InboundTask> _gridBloc;
+  StreamSubscription<String>? _scanSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<InboundTaskBloc>(context);
+    _gridBloc = _bloc.gridBloc;
+    final role = _bloc.currentQuery.roleOrUserId;
+    _bloc.add(SetInboundTaskUserScopeEvent(userId: 'ALL', roleOrUserId: role));
+    _bloc.add(const FilterInboundTasksEvent('1'));
+
+    _scanSubscription = ScannerService.instance.stream.listen(
+      (code) {
+        if (!mounted) return;
+        if (!(ModalRoute.of(context)?.isCurrent ?? false)) return;
+        final trimmed = code.trim();
+        if (trimmed.isEmpty) return;
+        _bloc.add(SearchInboundTasksEvent(trimmed));
+      },
+      onError: (error, __) {
+        if (!mounted) return;
+        LoadingDialogManager.instance.showErrorDialog(
+          context,
+          '扫码异常：$error',
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _scanSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar(title: '待接收任务').appBar,
+      body: BlocProvider.value(
+        value: _gridBloc,
+        child: BlocConsumer<CommonDataGridBloc<InboundTask>, CommonDataGridState<InboundTask>>(
+          listener: (context, state) {
+            if (state.status == GridStatus.loading) {
+              LoadingDialogManager.instance.showLoadingDialog(context);
+            } else {
+              LoadingDialogManager.instance.hideLoadingDialog(context);
+            }
+            if (state.status == GridStatus.error) {
+              LoadingDialogManager.instance.showErrorDialog(
+                context,
+                state.errorMessage ?? '加载接收任务失败',
+              );
+            }
+          },
+          builder: (context, state) {
+            return CommonDataGrid<InboundTask>(
+              columns: InboundTaskGridConfig.buildColumns(
+                _onOperate,
+                includeCollect: false,
+              ),
+              data: state.data ?? const [],
+              currentPage: state.currentPage,
+              totalPages: state.totalPages,
+              onLoadData: (index) async => _gridBloc.add(LoadDataEvent(index)),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  void _onOperate(InboundTask task, InboundTaskOperationType type) {
+    if (type == InboundTaskOperationType.detail) {
+      Modular.to.pushNamed(
+        '/floor-inbound/detail/${task.inTaskId}',
+        arguments: {
+          'task': task,
+          'workStation': task.workStation,
+          'receiveMode': true,
+        },
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extend the floor inbound collection flow with barcode parsing for KW sites, hazard production/expiry capture, serial de-duplication, and enriched submission payloads
- decode MC/KW scans in the task detail search while wiring a receive-only flag through the module so the receive view hides cancellation actions
- replace the task grid action cell with configurable buttons and adjust the receive page to list only detail actions

## Testing
- not run (Dart/Flutter toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df0927a3b083309498d4e69290ec85