### PR TITLE
feat: implement arrival collection workflow

### DIFF
--- a/wms_app_flutter/lib/modules/arrival/arrival_module.dart
+++ b/wms_app_flutter/lib/modules/arrival/arrival_module.dart
@@ -2,6 +2,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:wms_app/app_module.dart';
 import 'package:wms_app/modules/arrival/collection_task/arrival_collection_page.dart';
+import 'package:wms_app/modules/arrival/collection_task/bloc/arrival_collection_bloc.dart';
 import 'package:wms_app/modules/arrival/services/arrival_service.dart';
 import 'package:wms_app/modules/arrival/task_details/arrival_task_detail_page.dart';
 import 'package:wms_app/modules/arrival/task_list/arrival_task_list_page.dart';
@@ -27,6 +28,10 @@ class ArrivalModule extends Module {
 
     i.add<ArrivalTaskReceiveBloc>(
       () => ArrivalTaskReceiveBloc(service: i.get<ArrivalService>()),
+    );
+
+    i.add<ArrivalCollectionBloc>(
+      () => ArrivalCollectionBloc(service: i.get<ArrivalService>()),
     );
   }
 
@@ -82,7 +87,10 @@ class ArrivalModule extends Module {
         if (task == null) {
           throw ArgumentError('缺少到货任务数据');
         }
-        return ArrivalCollectionPage(task: task);
+        return BlocProvider(
+          create: (context) => Modular.get<ArrivalCollectionBloc>(),
+          child: ArrivalCollectionPage(task: task),
+        );
       },
     );
   }

--- a/wms_app_flutter/lib/modules/arrival/collection_task/arrival_collection_page.dart
+++ b/wms_app_flutter/lib/modules/arrival/collection_task/arrival_collection_page.dart
@@ -1,49 +1,395 @@
-import 'package:flutter/material.dart';
-import 'package:wms_app/common_widgets/custom_app_bar.dart';
-import 'package:wms_app/modules/arrival/task_list/models/arrival_task.dart';
+import 'dart:async';
 
-/// TODO: 采集功能将在后续迭代中补充完整
-class ArrivalCollectionPage extends StatelessWidget {
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/modules/arrival/collection_task/bloc/arrival_collection_bloc.dart';
+import 'package:wms_app/modules/arrival/collection_task/bloc/arrival_collection_event.dart';
+import 'package:wms_app/modules/arrival/collection_task/bloc/arrival_collection_state.dart';
+import 'package:wms_app/modules/arrival/collection_task/models/arrival_collection_models.dart';
+import 'package:wms_app/modules/arrival/task_list/models/arrival_task.dart';
+import 'package:wms_app/services/scanner_service.dart';
+
+class ArrivalCollectionPage extends StatefulWidget {
   const ArrivalCollectionPage({super.key, required this.task});
 
   final ArrivalTask task;
+
+  @override
+  State<ArrivalCollectionPage> createState() => _ArrivalCollectionPageState();
+}
+
+class _ArrivalCollectionPageState extends State<ArrivalCollectionPage> {
+  late final ArrivalCollectionBloc _bloc;
+  final TextEditingController _scanController = TextEditingController();
+  final FocusNode _scanFocusNode = FocusNode();
+  StreamSubscription<String>? _scanSubscription;
+  bool _isPromptVisible = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<ArrivalCollectionBloc>(context);
+    _bloc.add(InitializeArrivalCollection(task: widget.task));
+    _scanSubscription = ScannerService.instance.stream.listen(_handleScan);
+  }
+
+  @override
+  void dispose() {
+    _scanSubscription?.cancel();
+    _scanController.dispose();
+    _scanFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _handleScan(String code) {
+    if (!mounted) return;
+    if (!(ModalRoute.of(context)?.isCurrent ?? false)) return;
+    final trimmed = code.trim();
+    if (trimmed.isEmpty) return;
+    _scanController.text = trimmed;
+    _bloc.add(ArrivalCollectionScanReceived(trimmed));
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: CustomAppBar(
         title: '到货签收采集',
-        onBackPressed: () => Navigator.of(context).pop(),
+        onBackPressed: () => Modular.to.pop(),
       ).appBar,
-      body: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              '到货单号：${task.arrivalsBillNo}',
-              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-            ),
-            const SizedBox(height: 12),
-            Text('装箱单号：${task.orderNo}'),
-            Text('采购单号：${task.poNumber}'),
-            Text('供应商：${task.supplierName}'),
-            const SizedBox(height: 24),
-            const Card(
-              elevation: 0,
-              color: Color(0xFFF6F6F6),
-              child: Padding(
-                padding: EdgeInsets.all(16),
-                child: Text(
-                  '采集流程将参考 UniApp 逻辑拆分为扫码、采集结果与提交三个步骤。'
-                  ' 当前页面作为占位，后续将补充扫码监听、采集结果表格、提交接口对接等能力。',
-                  style: TextStyle(fontSize: 14, height: 1.6),
+      body: BlocConsumer<ArrivalCollectionBloc, ArrivalCollectionState>(
+        listener: _onStateChanged,
+        builder: (context, state) {
+          if (state.isLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          return Column(
+            children: [
+              _buildTaskHeader(widget.task),
+              _buildScanInput(state),
+              if (state.isSubmitting)
+                const LinearProgressIndicator(minHeight: 2),
+              _buildTabSelector(state),
+              Expanded(
+                child: IndexedStack(
+                  index: state.currentTab,
+                  children: [
+                    _buildDetailList(state),
+                    _buildRecordList(state),
+                  ],
                 ),
               ),
+              _buildSubmitBar(state),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  void _onStateChanged(BuildContext context, ArrivalCollectionState state) {
+    if (state.errorMessage != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(state.errorMessage!)),
+      );
+      _bloc.add(const ArrivalCollectionMessagesCleared());
+    }
+    if (state.successMessage != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(state.successMessage!)),
+      );
+      _bloc.add(const ArrivalCollectionMessagesCleared());
+    }
+
+    if (state.prompt != null && !_isPromptVisible) {
+      _showQuantityDialog(state.prompt!);
+    }
+  }
+
+  Widget _buildTaskHeader(ArrivalTask task) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      color: Colors.white,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '到货单号：${task.arrivalsBillNo}',
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 6),
+          Wrap(
+            spacing: 16,
+            runSpacing: 4,
+            children: [
+              Text('装箱单号：${task.orderNo}'),
+              Text('采购单号：${task.poNumber}'),
+              Text('供应商：${task.supplierName}'),
+              Text('到货日期：${task.createDate}'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScanInput(ArrivalCollectionState state) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      color: Colors.white,
+      child: TextField(
+        controller: _scanController,
+        focusNode: _scanFocusNode,
+        decoration: InputDecoration(
+          labelText: '扫描/输入物料条码',
+          hintText: state.placeholder,
+          suffixIcon: IconButton(
+            icon: const Icon(Icons.qr_code_scanner),
+            onPressed: () {
+              _scanController.clear();
+              _scanFocusNode.requestFocus();
+            },
+          ),
+          border: const OutlineInputBorder(),
+        ),
+        textInputAction: TextInputAction.done,
+        onSubmitted: (value) {
+          final trimmed = value.trim();
+          if (trimmed.isEmpty) return;
+          _bloc.add(ArrivalCollectionScanReceived(trimmed));
+        },
+      ),
+    );
+  }
+
+  Widget _buildTabSelector(ArrivalCollectionState state) {
+    return Container(
+      color: Colors.white,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        children: [
+          ChoiceChip(
+            label: const Text('任务列表'),
+            selected: state.currentTab == 0,
+            onSelected: (_) =>
+                _bloc.add(const ArrivalCollectionTabChanged(0)),
+          ),
+          const SizedBox(width: 12),
+          ChoiceChip(
+            label: Text('采集结果 (${state.records.length})'),
+            selected: state.currentTab == 1,
+            onSelected: (_) =>
+                _bloc.add(const ArrivalCollectionTabChanged(1)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDetailList(ArrivalCollectionState state) {
+    if (state.details.isEmpty) {
+      return const Center(child: Text('暂无任务明细'));
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.all(12),
+      itemCount: state.details.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 8),
+      itemBuilder: (context, index) {
+        final detail = state.details[index];
+        final remaining = (detail.planQty - detail.collectedQty).clamp(0, detail.planQty);
+        return Card(
+          elevation: 0,
+          child: ListTile(
+            title: Text(
+              '${detail.materialCode}  ${detail.materialName}',
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+            subtitle: Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('批次：${detail.batchNo.isEmpty ? '-' : detail.batchNo}'),
+                  Text('序列：${detail.serialNo.isEmpty ? '-' : detail.serialNo}'),
+                  Text('控制属性：${detail.controlMode.isEmpty ? '-' : detail.controlMode}'),
+                  Text('库房/子库：${detail.storeRoom} / ${detail.subInventory}'),
+                ],
+              ),
+            ),
+            trailing: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text('任务：${detail.planQty.toStringAsFixed(2)}'),
+                Text('已采：${detail.collectedQty.toStringAsFixed(2)}'),
+                Text('剩余：${remaining.toStringAsFixed(2)}'),
+              ],
+            ),
+            onTap: () => _bloc.add(ArrivalCollectionDetailSelected(detail)),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildRecordList(ArrivalCollectionState state) {
+    if (state.records.isEmpty) {
+      return const Center(child: Text('尚未采集任何明细'));
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.all(12),
+      itemCount: state.records.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 8),
+      itemBuilder: (context, index) {
+        final record = state.records[index];
+        return Card(
+          elevation: 0,
+          child: ListTile(
+            title: Text('${record.materialCode}  ${record.materialName}'),
+            subtitle: Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('批次：${record.batchNo?.isNotEmpty == true ? record.batchNo : '-'}'),
+                  Text('序列：${record.serialNo?.isNotEmpty == true ? record.serialNo : '-'}'),
+                  Text('采集标记：${record.collectFlag == '0' ? '匹配' : '不匹配'}'),
+                ],
+              ),
+            ),
+            trailing: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text('数量：${record.quantity.toStringAsFixed(2)}'),
+                IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  tooltip: '删除记录',
+                  onPressed: () =>
+                      _bloc.add(ArrivalCollectionRecordRemoved(record.id)),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSubmitBar(ArrivalCollectionState state) {
+    final totalQuantity = state.records.fold<double>(
+      0,
+      (previousValue, element) => previousValue + element.quantity,
+    );
+
+    return SafeArea(
+      top: false,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          boxShadow: [
+            BoxShadow(
+              color: Color(0x11000000),
+              offset: Offset(0, -2),
+              blurRadius: 8,
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                '本次采集合计：${totalQuantity.toStringAsFixed(2)}',
+                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+              ),
+            ),
+            ElevatedButton.icon(
+              onPressed: state.isSubmitting
+                  ? null
+                  : () => _bloc.add(const ArrivalCollectionSubmitRequested()),
+              icon: const Icon(Icons.check_circle_outline),
+              label: const Text('提交'),
             ),
           ],
         ),
       ),
     );
+  }
+
+  Future<void> _showQuantityDialog(ArrivalCollectionPrompt prompt) async {
+    _isPromptVisible = true;
+    final controller = TextEditingController(
+      text: prompt.suggestedQty != null
+          ? prompt.suggestedQty!.toStringAsFixed(2)
+          : '',
+    );
+
+    final detail = prompt.detail;
+    final remaining = prompt.remainingQty;
+
+    final result = await showDialog<double>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('采集 ${detail.materialCode}'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('物料：${detail.materialName}'),
+              const SizedBox(height: 8),
+              Text('剩余数量：${remaining.toStringAsFixed(2)}'),
+              const SizedBox(height: 16),
+              TextField(
+                controller: controller,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                decoration: const InputDecoration(
+                  labelText: '采集数量',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('取消'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final value = double.tryParse(controller.text.trim());
+                if (value == null) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('请输入正确的数字')),
+                  );
+                  return;
+                }
+                Navigator.of(context).pop(value);
+              },
+              child: const Text('确认'),
+            ),
+          ],
+        );
+      },
+    );
+
+    _isPromptVisible = false;
+    if (!mounted) return;
+
+    if (result != null) {
+      _bloc.add(ArrivalCollectionQuantitySubmitted(result));
+    } else {
+      _bloc.add(const ArrivalCollectionPromptDismissed());
+    }
   }
 }

--- a/wms_app_flutter/lib/modules/arrival/collection_task/bloc/arrival_collection_bloc.dart
+++ b/wms_app_flutter/lib/modules/arrival/collection_task/bloc/arrival_collection_bloc.dart
@@ -1,0 +1,428 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:uuid/uuid.dart';
+import 'package:wms_app/modules/arrival/collection_task/bloc/arrival_collection_event.dart';
+import 'package:wms_app/modules/arrival/collection_task/bloc/arrival_collection_state.dart';
+import 'package:wms_app/modules/arrival/collection_task/models/arrival_collection_models.dart';
+import 'package:wms_app/modules/arrival/services/arrival_service.dart';
+import 'package:wms_app/modules/arrival/task_details/models/arrival_task_detail.dart';
+import 'package:wms_app/modules/arrival/task_list/models/arrival_task.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/models/inbound_collection_models.dart';
+
+class ArrivalCollectionBloc
+    extends Bloc<ArrivalCollectionEvent, ArrivalCollectionState> {
+  ArrivalCollectionBloc({required ArrivalService service})
+      : _service = service,
+        super(const ArrivalCollectionState()) {
+    on<InitializeArrivalCollection>(_onInitialize);
+    on<ArrivalCollectionScanReceived>(_onScanReceived);
+    on<ArrivalCollectionDetailSelected>(_onDetailSelected);
+    on<ArrivalCollectionQuantitySubmitted>(_onQuantitySubmitted);
+    on<ArrivalCollectionPromptDismissed>(_onPromptDismissed);
+    on<ArrivalCollectionRecordRemoved>(_onRecordRemoved);
+    on<ArrivalCollectionSubmitRequested>(_onSubmitRequested);
+    on<ArrivalCollectionMessagesCleared>(_onMessagesCleared);
+    on<ArrivalCollectionTabChanged>(_onTabChanged);
+  }
+
+  final ArrivalService _service;
+  final Uuid _uuid = const Uuid();
+  ArrivalTaskDetailQuery? _currentQuery;
+
+  Future<void> _onInitialize(
+    InitializeArrivalCollection event,
+    Emitter<ArrivalCollectionState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        task: event.task,
+        isLoading: true,
+        records: const [],
+        errorMessage: null,
+        successMessage: null,
+        clearError: true,
+        clearSuccess: true,
+      ),
+    );
+
+    try {
+      _currentQuery = ArrivalTaskDetailQuery(arrivalsBillId: event.task.arrivalsBillId);
+      final result = await _service.getArrivalDetails(_currentQuery!);
+      final initialCollected = <String, double>{
+        for (final item in result.rows) item.detailId: item.collectedQty,
+      };
+      emit(
+        state.copyWith(
+          isLoading: false,
+          details: result.rows,
+          initialCollected: initialCollected,
+          currentTab: 0,
+        ),
+      );
+    } catch (e) {
+      emit(
+        state.copyWith(
+          isLoading: false,
+          errorMessage: e.toString(),
+          clearSuccess: true,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onScanReceived(
+    ArrivalCollectionScanReceived event,
+    Emitter<ArrivalCollectionState> emit,
+  ) async {
+    final task = state.task;
+    if (task == null) {
+      return;
+    }
+    final code = event.code.trim();
+    if (code.isEmpty) {
+      return;
+    }
+
+    emit(state.copyWith(clearError: true, clearSuccess: true));
+
+    try {
+      final material = await _service.getMaterialInfo(code);
+      final detail = _findDetailForMaterial(material, state.details);
+      if (detail == null) {
+        emit(
+          state.copyWith(
+            errorMessage: '物料【${material.matCode}】不在当前任务中或已采集完成',
+          ),
+        );
+        return;
+      }
+
+      final remaining = _remainingQty(detail);
+      if (remaining <= 0) {
+        emit(
+          state.copyWith(
+            errorMessage: '物料【${detail.materialCode}】已完成采集',
+          ),
+        );
+        return;
+      }
+
+      double? suggested;
+      if (material.qty != null && material.qty! > 0) {
+        suggested = material.qty! <= remaining ? material.qty! : remaining;
+      } else if ((material.sn ?? '').isNotEmpty) {
+        suggested = 1;
+      }
+
+      emit(
+        state.copyWith(
+          prompt: ArrivalCollectionPrompt(
+            detail: detail,
+            material: material,
+            remainingQty: remaining,
+            suggestedQty: suggested,
+          ),
+        ),
+      );
+    } catch (e) {
+      emit(state.copyWith(errorMessage: e.toString()));
+    }
+  }
+
+  void _onDetailSelected(
+    ArrivalCollectionDetailSelected event,
+    Emitter<ArrivalCollectionState> emit,
+  ) {
+    final remaining = _remainingQty(event.detail);
+    if (remaining <= 0) {
+      emit(
+        state.copyWith(
+          errorMessage: '物料【${event.detail.materialCode}】已完成采集',
+        ),
+      );
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        prompt: ArrivalCollectionPrompt(
+          detail: event.detail,
+          material: null,
+          remainingQty: remaining,
+          suggestedQty: remaining,
+        ),
+        clearError: true,
+        clearSuccess: true,
+      ),
+    );
+  }
+
+  void _onPromptDismissed(
+    ArrivalCollectionPromptDismissed event,
+    Emitter<ArrivalCollectionState> emit,
+  ) {
+    emit(state.copyWith(clearPrompt: true));
+  }
+
+  void _onMessagesCleared(
+    ArrivalCollectionMessagesCleared event,
+    Emitter<ArrivalCollectionState> emit,
+  ) {
+    emit(state.copyWith(clearError: true, clearSuccess: true));
+  }
+
+  void _onTabChanged(
+    ArrivalCollectionTabChanged event,
+    Emitter<ArrivalCollectionState> emit,
+  ) {
+    emit(state.copyWith(currentTab: event.index));
+  }
+
+  Future<void> _onQuantitySubmitted(
+    ArrivalCollectionQuantitySubmitted event,
+    Emitter<ArrivalCollectionState> emit,
+  ) async {
+    final prompt = state.prompt;
+    final task = state.task;
+    if (prompt == null || task == null) {
+      return;
+    }
+
+    final quantity = event.quantity;
+    if (quantity <= 0) {
+      emit(
+        state.copyWith(
+          errorMessage: '采集数量必须大于0',
+          clearSuccess: true,
+        ),
+      );
+      return;
+    }
+
+    if (quantity > prompt.remainingQty + 1e-6) {
+      emit(
+        state.copyWith(
+          errorMessage: '采集数量不能超过剩余任务数量${prompt.remainingQty.toStringAsFixed(2)}',
+          clearSuccess: true,
+        ),
+      );
+      return;
+    }
+
+    final material = prompt.material;
+    final detail = prompt.detail;
+    final batch = (material?.batchNo?.isNotEmpty ?? false)
+        ? material!.batchNo
+        : (detail.batchNo.isNotEmpty ? detail.batchNo : null);
+    final serial = (material?.sn?.isNotEmpty ?? false) ? material!.sn : null;
+
+    final matchesBatch = detail.batchNo.isEmpty ||
+        batch == null ||
+        detail.batchNo == batch;
+    final matchesSerial = detail.serialNo.isEmpty ||
+        serial == null ||
+        detail.serialNo == serial;
+    final collectFlag = (matchesBatch && matchesSerial) ? '0' : '1';
+
+    final record = ArrivalCollectionRecord(
+      id: _uuid.v4(),
+      detailId: detail.detailId,
+      arrivalsBillId: task.arrivalsBillId,
+      materialCode: detail.materialCode,
+      materialName: detail.materialName,
+      batchNo: batch,
+      serialNo: serial,
+      quantity: quantity,
+      taskQty: detail.planQty,
+      storeRoom: detail.storeRoom,
+      subInventory: detail.subInventory,
+      supplierName: detail.supplierName.isNotEmpty
+          ? detail.supplierName
+          : material?.supplierName,
+      collectFlag: collectFlag,
+      productionDate: material?.productionDate,
+      validDays: material?.validDays,
+    );
+
+    final updatedRecords = List<ArrivalCollectionRecord>.from(state.records);
+    final index =
+        updatedRecords.indexWhere((element) => element.isSameTarget(record));
+    if (index >= 0) {
+      final existing = updatedRecords[index];
+      updatedRecords[index] =
+          existing.copyWith(quantity: existing.quantity + record.quantity);
+    } else {
+      updatedRecords.add(record);
+    }
+
+    final updatedDetails = state.details.map((item) {
+      if (item.detailId == detail.detailId) {
+        final newQty = item.collectedQty + quantity;
+        return item.copyWith(collectedQty: newQty);
+      }
+      return item;
+    }).toList();
+
+    emit(
+      state.copyWith(
+        records: updatedRecords,
+        details: updatedDetails,
+        successMessage: '采集成功',
+        currentTab: 1,
+        clearError: true,
+        clearPrompt: true,
+      ),
+    );
+  }
+
+  void _onRecordRemoved(
+    ArrivalCollectionRecordRemoved event,
+    Emitter<ArrivalCollectionState> emit,
+  ) {
+    final targetIndex =
+        state.records.indexWhere((element) => element.id == event.recordId);
+    if (targetIndex < 0) {
+      return;
+    }
+
+    final target = state.records[targetIndex];
+    final updatedRecords = List<ArrivalCollectionRecord>.from(state.records)
+      ..removeAt(targetIndex);
+
+    final updatedDetails = state.details.map((item) {
+      if (item.detailId == target.detailId) {
+        final newQty = (item.collectedQty - target.quantity).clamp(0, item.planQty);
+        return item.copyWith(collectedQty: newQty);
+      }
+      return item;
+    }).toList();
+
+    emit(
+      state.copyWith(
+        records: updatedRecords,
+        details: updatedDetails,
+        successMessage: '已移除采集记录',
+        clearError: true,
+      ),
+    );
+  }
+
+  Future<void> _onSubmitRequested(
+    ArrivalCollectionSubmitRequested event,
+    Emitter<ArrivalCollectionState> emit,
+  ) async {
+    final task = state.task;
+    if (task == null) {
+      return;
+    }
+    if (state.records.isEmpty) {
+      emit(
+        state.copyWith(
+          errorMessage: '本次无采集记录，请先采集后再提交',
+          clearSuccess: true,
+        ),
+      );
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        isSubmitting: true,
+        clearError: true,
+        clearSuccess: true,
+      ),
+    );
+
+    try {
+      await _service.submitArrivalCollection(
+        task: task,
+        records: state.records,
+        details: state.details,
+        initialCollected: state.initialCollected,
+      );
+
+      if (_currentQuery != null) {
+        final refreshed = await _service.getArrivalDetails(_currentQuery!);
+        final initialCollected = <String, double>{
+          for (final item in refreshed.rows) item.detailId: item.collectedQty,
+        };
+        emit(
+          state.copyWith(
+            details: refreshed.rows,
+            records: const [],
+            initialCollected: initialCollected,
+            successMessage: '提交成功',
+            isSubmitting: false,
+            currentTab: 0,
+            clearPrompt: true,
+          ),
+        );
+      } else {
+        emit(
+          state.copyWith(
+            records: const [],
+            successMessage: '提交成功',
+            isSubmitting: false,
+            currentTab: 0,
+            clearPrompt: true,
+          ),
+        );
+      }
+    } catch (e) {
+      emit(
+        state.copyWith(
+          isSubmitting: false,
+          errorMessage: e.toString(),
+          clearPrompt: true,
+        ),
+      );
+    }
+  }
+
+  ArrivalTaskDetail? _findDetailForMaterial(
+    InboundBarcodeContent material,
+    List<ArrivalTaskDetail> details,
+  ) {
+    final candidates = details.where((item) {
+      if (item.materialCode != material.matCode) {
+        return false;
+      }
+      final remaining = _remainingQty(item);
+      if (remaining <= 0) {
+        return false;
+      }
+      if ((material.batchNo?.isNotEmpty ?? false) && item.batchNo.isNotEmpty) {
+        if (item.batchNo != material.batchNo) {
+          return false;
+        }
+      }
+      if ((material.sn?.isNotEmpty ?? false) && item.serialNo.isNotEmpty) {
+        if (item.serialNo != material.sn) {
+          return false;
+        }
+      }
+      return true;
+    }).toList();
+
+    if (candidates.isEmpty) {
+      final fallback = details.where((item) =>
+          item.materialCode == material.matCode && _remainingQty(item) > 0).toList();
+      if (fallback.isEmpty) {
+        return null;
+      }
+      fallback.sort((a, b) => _remainingQty(b).compareTo(_remainingQty(a)));
+      return fallback.first;
+    }
+
+    candidates.sort(
+      (a, b) => _remainingQty(b).compareTo(_remainingQty(a)),
+    );
+    return candidates.first;
+  }
+
+  double _remainingQty(ArrivalTaskDetail detail) {
+    final remaining = detail.planQty - detail.collectedQty;
+    return remaining < 0 ? 0 : remaining;
+  }
+}

--- a/wms_app_flutter/lib/modules/arrival/collection_task/bloc/arrival_collection_event.dart
+++ b/wms_app_flutter/lib/modules/arrival/collection_task/bloc/arrival_collection_event.dart
@@ -1,0 +1,76 @@
+import 'package:equatable/equatable.dart';
+import 'package:wms_app/modules/arrival/task_details/models/arrival_task_detail.dart';
+import 'package:wms_app/modules/arrival/task_list/models/arrival_task.dart';
+
+abstract class ArrivalCollectionEvent extends Equatable {
+  const ArrivalCollectionEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class InitializeArrivalCollection extends ArrivalCollectionEvent {
+  const InitializeArrivalCollection({required this.task});
+
+  final ArrivalTask task;
+
+  @override
+  List<Object?> get props => [task];
+}
+
+class ArrivalCollectionScanReceived extends ArrivalCollectionEvent {
+  const ArrivalCollectionScanReceived(this.code);
+
+  final String code;
+
+  @override
+  List<Object?> get props => [code];
+}
+
+class ArrivalCollectionDetailSelected extends ArrivalCollectionEvent {
+  const ArrivalCollectionDetailSelected(this.detail);
+
+  final ArrivalTaskDetail detail;
+
+  @override
+  List<Object?> get props => [detail];
+}
+
+class ArrivalCollectionQuantitySubmitted extends ArrivalCollectionEvent {
+  const ArrivalCollectionQuantitySubmitted(this.quantity);
+
+  final double quantity;
+
+  @override
+  List<Object?> get props => [quantity];
+}
+
+class ArrivalCollectionPromptDismissed extends ArrivalCollectionEvent {
+  const ArrivalCollectionPromptDismissed();
+}
+
+class ArrivalCollectionRecordRemoved extends ArrivalCollectionEvent {
+  const ArrivalCollectionRecordRemoved(this.recordId);
+
+  final String recordId;
+
+  @override
+  List<Object?> get props => [recordId];
+}
+
+class ArrivalCollectionSubmitRequested extends ArrivalCollectionEvent {
+  const ArrivalCollectionSubmitRequested();
+}
+
+class ArrivalCollectionMessagesCleared extends ArrivalCollectionEvent {
+  const ArrivalCollectionMessagesCleared();
+}
+
+class ArrivalCollectionTabChanged extends ArrivalCollectionEvent {
+  const ArrivalCollectionTabChanged(this.index);
+
+  final int index;
+
+  @override
+  List<Object?> get props => [index];
+}

--- a/wms_app_flutter/lib/modules/arrival/collection_task/bloc/arrival_collection_state.dart
+++ b/wms_app_flutter/lib/modules/arrival/collection_task/bloc/arrival_collection_state.dart
@@ -1,0 +1,78 @@
+import 'package:equatable/equatable.dart';
+import 'package:wms_app/modules/arrival/collection_task/models/arrival_collection_models.dart';
+import 'package:wms_app/modules/arrival/task_details/models/arrival_task_detail.dart';
+import 'package:wms_app/modules/arrival/task_list/models/arrival_task.dart';
+
+class ArrivalCollectionState extends Equatable {
+  const ArrivalCollectionState({
+    this.task,
+    this.isLoading = false,
+    this.isSubmitting = false,
+    this.details = const [],
+    this.records = const [],
+    this.initialCollected = const {},
+    this.prompt,
+    this.errorMessage,
+    this.successMessage,
+    this.currentTab = 0,
+    this.placeholder = '请扫描物料二维码',
+  });
+
+  final ArrivalTask? task;
+  final bool isLoading;
+  final bool isSubmitting;
+  final List<ArrivalTaskDetail> details;
+  final List<ArrivalCollectionRecord> records;
+  final Map<String, double> initialCollected;
+  final ArrivalCollectionPrompt? prompt;
+  final String? errorMessage;
+  final String? successMessage;
+  final int currentTab;
+  final String placeholder;
+
+  ArrivalCollectionState copyWith({
+    ArrivalTask? task,
+    bool? isLoading,
+    bool? isSubmitting,
+    List<ArrivalTaskDetail>? details,
+    List<ArrivalCollectionRecord>? records,
+    Map<String, double>? initialCollected,
+    ArrivalCollectionPrompt? prompt,
+    bool clearPrompt = false,
+    String? errorMessage,
+    String? successMessage,
+    bool clearError = false,
+    bool clearSuccess = false,
+    int? currentTab,
+    String? placeholder,
+  }) {
+    return ArrivalCollectionState(
+      task: task ?? this.task,
+      isLoading: isLoading ?? this.isLoading,
+      isSubmitting: isSubmitting ?? this.isSubmitting,
+      details: details ?? this.details,
+      records: records ?? this.records,
+      initialCollected: initialCollected ?? this.initialCollected,
+      prompt: clearPrompt ? null : (prompt ?? this.prompt),
+      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+      successMessage: clearSuccess ? null : (successMessage ?? this.successMessage),
+      currentTab: currentTab ?? this.currentTab,
+      placeholder: placeholder ?? this.placeholder,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        task,
+        isLoading,
+        isSubmitting,
+        details,
+        records,
+        initialCollected,
+        prompt,
+        errorMessage,
+        successMessage,
+        currentTab,
+        placeholder,
+      ];
+}

--- a/wms_app_flutter/lib/modules/arrival/collection_task/models/arrival_collection_models.dart
+++ b/wms_app_flutter/lib/modules/arrival/collection_task/models/arrival_collection_models.dart
@@ -1,0 +1,102 @@
+import 'package:equatable/equatable.dart';
+import 'package:wms_app/modules/arrival/task_details/models/arrival_task_detail.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/models/inbound_collection_models.dart';
+
+class ArrivalCollectionPrompt extends Equatable {
+  const ArrivalCollectionPrompt({
+    required this.detail,
+    this.material,
+    required this.remainingQty,
+    this.suggestedQty,
+  });
+
+  final ArrivalTaskDetail detail;
+  final InboundBarcodeContent? material;
+  final double remainingQty;
+  final double? suggestedQty;
+
+  @override
+  List<Object?> get props => [detail, material, remainingQty, suggestedQty];
+}
+
+class ArrivalCollectionRecord extends Equatable {
+  const ArrivalCollectionRecord({
+    required this.id,
+    required this.detailId,
+    required this.arrivalsBillId,
+    required this.materialCode,
+    required this.materialName,
+    this.batchNo,
+    this.serialNo,
+    required this.quantity,
+    required this.taskQty,
+    required this.storeRoom,
+    this.subInventory,
+    this.supplierName,
+    required this.collectFlag,
+    this.productionDate,
+    this.validDays,
+  });
+
+  final String id;
+  final String detailId;
+  final String arrivalsBillId;
+  final String materialCode;
+  final String materialName;
+  final String? batchNo;
+  final String? serialNo;
+  final double quantity;
+  final double taskQty;
+  final String storeRoom;
+  final String? subInventory;
+  final String? supplierName;
+  final String collectFlag;
+  final DateTime? productionDate;
+  final int? validDays;
+
+  ArrivalCollectionRecord copyWith({double? quantity}) {
+    return ArrivalCollectionRecord(
+      id: id,
+      detailId: detailId,
+      arrivalsBillId: arrivalsBillId,
+      materialCode: materialCode,
+      materialName: materialName,
+      batchNo: batchNo,
+      serialNo: serialNo,
+      quantity: quantity ?? this.quantity,
+      taskQty: taskQty,
+      storeRoom: storeRoom,
+      subInventory: subInventory,
+      supplierName: supplierName,
+      collectFlag: collectFlag,
+      productionDate: productionDate,
+      validDays: validDays,
+    );
+  }
+
+  bool isSameTarget(ArrivalCollectionRecord other) {
+    return detailId == other.detailId &&
+        (batchNo ?? '') == (other.batchNo ?? '') &&
+        (serialNo ?? '') == (other.serialNo ?? '') &&
+        collectFlag == other.collectFlag;
+  }
+
+  @override
+  List<Object?> get props => [
+        id,
+        detailId,
+        arrivalsBillId,
+        materialCode,
+        materialName,
+        batchNo,
+        serialNo,
+        quantity,
+        taskQty,
+        storeRoom,
+        subInventory,
+        supplierName,
+        collectFlag,
+        productionDate,
+        validDays,
+      ];
+}

--- a/wms_app_flutter/lib/modules/arrival/services/arrival_service.dart
+++ b/wms_app_flutter/lib/modules/arrival/services/arrival_service.dart
@@ -1,6 +1,8 @@
 import 'package:dio/dio.dart';
+import 'package:wms_app/modules/arrival/collection_task/models/arrival_collection_models.dart';
 import 'package:wms_app/modules/arrival/task_details/models/arrival_task_detail.dart';
 import 'package:wms_app/modules/arrival/task_list/models/arrival_task.dart';
+import 'package:wms_app/modules/floor_inbound/collection_task/models/inbound_collection_models.dart';
 import 'package:wms_app/services/api_response_handler.dart';
 
 /// 到货接收相关接口封装
@@ -82,5 +84,84 @@ class ArrivalService {
         Map<String, dynamic>.from(data as Map<dynamic, dynamic>),
       ),
     );
+  }
+
+  /// 扫码查询物料信息
+  Future<InboundBarcodeContent> getMaterialInfo(String barcode) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/materialInfo',
+      queryParameters: {'QRstring': barcode},
+    );
+
+    final data = response.data;
+    if (data is! Map<String, dynamic>) {
+      throw Exception('物料条码识别失败');
+    }
+    if (data['code'] != 200 || data['data'] == null) {
+      throw Exception(data['msg']?.toString() ?? '物料条码识别失败');
+    }
+
+    return InboundBarcodeContent.fromJson(
+      Map<String, dynamic>.from(data['data'] as Map<dynamic, dynamic>),
+    );
+  }
+
+  /// 提交到货采集结果
+  Future<void> submitArrivalCollection({
+    required ArrivalTask task,
+    required List<ArrivalCollectionRecord> records,
+    required List<ArrivalTaskDetail> details,
+    required Map<String, double> initialCollected,
+  }) async {
+    final upShelvesInfos = records
+        .map((record) => {
+              'taskNo': record.arrivalsBillId,
+              'matCode': record.materialCode,
+              'batchNo': record.batchNo,
+              'sn': record.serialNo,
+              'taskQty': record.taskQty,
+              'collectQty': record.quantity,
+              'storeRoomNo': record.storeRoom,
+              'storeSiteNo': '',
+              'taskid': record.arrivalsBillId,
+              'inTaskItemid': record.detailId,
+              'matchingFlg': record.collectFlag,
+              if (record.productionDate != null)
+                'data1': _formatDate(record.productionDate!),
+              if (record.validDays != null) 'data2': record.validDays,
+            })
+        .toList();
+
+    final itemListInfos = details
+        .map((detail) => {
+              'inTaskItemid': detail.detailId,
+              'mtlCode': detail.materialCode,
+              'mtlQty': [
+                initialCollected[detail.detailId] ?? detail.collectedQty,
+                detail.collectedQty,
+              ],
+            })
+        .toList();
+
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/system/terminal/commitSign',
+      data: {
+        'upShelvesInfos': upShelvesInfos,
+        'itemListInfos': itemListInfos,
+        'filter': '',
+      },
+      options: Options(
+        headers: {'content-type': 'application/json;charset=UTF-8'},
+      ),
+    );
+
+    ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => data,
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year.toString().padLeft(4, '0')}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
   }
 }

--- a/wms_app_flutter/lib/modules/arrival/task_details/config/arrival_task_detail_grid_config.dart
+++ b/wms_app_flutter/lib/modules/arrival/task_details/config/arrival_task_detail_grid_config.dart
@@ -50,6 +50,12 @@ class ArrivalTaskDetailGridConfig {
         valueGetter: (item) => item.serialNo,
       ),
       GridColumnConfig<ArrivalTaskDetail>(
+        name: 'controlMode',
+        headerText: '控制属性',
+        width: 120,
+        valueGetter: (item) => item.controlMode,
+      ),
+      GridColumnConfig<ArrivalTaskDetail>(
         name: 'storeroom',
         headerText: '库房',
         width: 120,
@@ -66,6 +72,18 @@ class ArrivalTaskDetailGridConfig {
         headerText: 'SAP行号',
         width: 120,
         valueGetter: (item) => item.sapLineNo,
+      ),
+      GridColumnConfig<ArrivalTaskDetail>(
+        name: 'orderno',
+        headerText: '装箱单号',
+        width: 150,
+        valueGetter: (item) => item.orderNo,
+      ),
+      GridColumnConfig<ArrivalTaskDetail>(
+        name: 'arrivalsBillno',
+        headerText: '到货单号',
+        width: 150,
+        valueGetter: (item) => item.arrivalsBillNo,
       ),
       GridColumnConfig<ArrivalTaskDetail>(
         name: 'supplier',

--- a/wms_app_flutter/lib/modules/arrival/task_details/models/arrival_task_detail.dart
+++ b/wms_app_flutter/lib/modules/arrival/task_details/models/arrival_task_detail.dart
@@ -14,6 +14,9 @@ class ArrivalTaskDetail extends Equatable {
     required this.subInventory,
     required this.sapLineNo,
     required this.supplierName,
+    required this.controlMode,
+    required this.orderNo,
+    required this.arrivalsBillNo,
   });
 
   factory ArrivalTaskDetail.fromJson(Map<String, dynamic> json) {
@@ -29,6 +32,9 @@ class ArrivalTaskDetail extends Equatable {
       subInventory: json['subinventoryCode']?.toString() ?? '',
       sapLineNo: json['posnr']?.toString() ?? '',
       supplierName: json['parname']?.toString() ?? '',
+      controlMode: json['matcodecontrol']?.toString() ?? '',
+      orderNo: json['orderno']?.toString() ?? '',
+      arrivalsBillNo: json['arrivalsBillno']?.toString() ?? '',
     );
   }
 
@@ -43,6 +49,28 @@ class ArrivalTaskDetail extends Equatable {
   final String subInventory;
   final String sapLineNo;
   final String supplierName;
+  final String controlMode;
+  final String orderNo;
+  final String arrivalsBillNo;
+
+  ArrivalTaskDetail copyWith({double? collectedQty}) {
+    return ArrivalTaskDetail(
+      detailId: detailId,
+      materialCode: materialCode,
+      materialName: materialName,
+      batchNo: batchNo,
+      serialNo: serialNo,
+      planQty: planQty,
+      collectedQty: collectedQty ?? this.collectedQty,
+      storeRoom: storeRoom,
+      subInventory: subInventory,
+      sapLineNo: sapLineNo,
+      supplierName: supplierName,
+      controlMode: controlMode,
+      orderNo: orderNo,
+      arrivalsBillNo: arrivalsBillNo,
+    );
+  }
 
   @override
   List<Object?> get props => [
@@ -57,6 +85,9 @@ class ArrivalTaskDetail extends Equatable {
         subInventory,
         sapLineNo,
         supplierName,
+        controlMode,
+        orderNo,
+        arrivalsBillNo,
       ];
 }
 


### PR DESCRIPTION
## Summary
- replace the placeholder arrival collection page with a bloc-driven workflow that supports scanning, manual entry and submission of records
- add arrival collection bloc/models and service methods to load barcode metadata and commit results to the backend
- extend arrival detail models and grid columns to expose control attributes and document numbers needed for the new UI

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df6c4df2908330af0793911f19335f